### PR TITLE
Update Linkerd version to stable-2.4.0

### DIFF
--- a/stacks/linkerd2/deploy-local.sh
+++ b/stacks/linkerd2/deploy-local.sh
@@ -3,7 +3,7 @@
 set -e
 
 ROOT_DIR=$(git rev-parse --show-toplevel)
-LINKERD2_VERSION="stable-2.3.2"
+LINKERD2_VERSION="stable-2.4.0"
 
 # check OS type
 if [ "$(uname -s)" = "Darwin" ]; then


### PR DESCRIPTION
The stable-2.4.0 release includes support for SMI split traffic, improved proxy performance, HA mode, default PSP, and many other good stuff. Full release notes can be found [here](https://github.com/linkerd/linkerd2/releases/tag/stable-2.4.0).

Signed-off-by: iIvan Sim <ivan@buoyant.io>