### PR TITLE
Add OpenFaaS chart 4.4.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,9 +13,14 @@ custom Helm values (if applicable), kustomize, or a combination of both.
 
 1. Clone the [digitalocean/marketplace-kubernetes](https://github.com/digitalocean/marketplace-kubernetes) repository
 2. Create a branch for your application
-3. If you’re application is deployed using Helm:
+3. If your application is deployed using Helm:
 
 ```bash
+
+export APP_NAME=""
+export HELM_CHART_NAME=""
+export HELM_CHART_VERSION=""
+
 # create a new directory for your application in src
 mkdir src/$APP_NAME
 cd src/$APP_NAME

--- a/src/openfaas/4.4.0/Chart.yaml
+++ b/src/openfaas/4.4.0/Chart.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+description: Enable Kubernetes as a backend for OpenFaaS (Functions as a Service)
+home: https://www.openfaas.com
+icon: https://raw.githubusercontent.com/openfaas/media/master/OpenFaaS_logo_stacked_opaque.png
+keywords:
+- functions
+- service
+maintainers:
+- email: alex@openfaas.com
+  name: alexellis
+- email: roesler.lucas@gmail.com
+  name: lucasroesler
+- email: stefan.prodan@gmail.com
+  name: stefanprodan
+- email: rmocius@gmail.com
+  name: rimusz
+name: openfaas
+sources:
+- https://github.com/openfaas/faas
+- https://github.com/openfaas/faas-netes
+version: 4.4.0

--- a/src/openfaas/4.4.0/OWNERS
+++ b/src/openfaas/4.4.0/OWNERS
@@ -1,0 +1,8 @@
+approvers:
+- alexellis
+- rimusz
+- LucasRoesler
+reviewers:
+- alexellis
+- rimusz
+- LucasRoesler

--- a/src/openfaas/4.4.0/README.md
+++ b/src/openfaas/4.4.0/README.md
@@ -1,0 +1,303 @@
+# OpenFaaS - Serverless Functions Made Simple
+
+![OpenFaaS Logo](https://blog.alexellis.io/content/images/2017/08/faas_side.png)
+
+[OpenFaaS](https://github.com/openfaas/faas) (Functions as a Service) is a framework for building serverless functions with Docker and Kubernetes which has first class support for metrics. Any process can be packaged as a function enabling you to consume a range of web events without repetitive boiler-plate coding.
+
+## Highlights
+
+* Ease of use through UI portal and *one-click* install
+* Write functions in any language for Linux or Windows and package in Docker/OCI image format
+* Portable - runs on existing hardware or public/private cloud. Native [Kubernetes](https://github.com/openfaas/faas-netes) support, Docker Swarm also available
+* [Operator / CRD option available](https://github.com/openfaas-incubator/openfaas-operator/)
+* [faas-cli](http://github.com/openfaas/faas-cli) available with stack.yml for creating and managing functions
+* Auto-scales according to metrics from Prometheus
+* Scales to zero and back again and can be tuned at a per-function level
+* Works with service-mesh
+    * Tested with [Istio](https://istio.io) including mTLS
+    * Tested with [Linkerd2](https://github.com/openfaas-incubator/openfaas-linkerd2) including mTLS
+
+## Deploy OpenFaaS
+
+**Note:** If your cluster is not configured with role-based access control, then pass `--set rbac=false`. For further information, see [Kubernetes: RBAC](https://kubernetes.io/docs/admin/authorization/rbac/).
+
+**Note:** If you can not use helm with Tiller, you can still use the `helm` CLI to [generate custom YAML](#deployment-with-helm-template) without server-side components.
+
+---
+### Install
+
+See also: [Install Helm](https://github.com/openfaas/faas-netes/blob/master/HELM.md)
+
+We recommend creating two namespaces, one for the OpenFaaS core services and one for the functions:
+
+```sh
+kubectl apply -f https://raw.githubusercontent.com/openfaas/faas-netes/master/namespaces.yml
+```
+
+You will now have `openfaas` and `openfaas-fn`. If you want to change the names or to install into multiple installations then edit `namespaces.yml` from the `faas-netes` repo.
+
+Add the OpenFaaS `helm` chart:
+
+```sh
+helm repo add openfaas https://openfaas.github.io/faas-netes/
+```
+
+Generate secrets so that we can enable basic authentication for the gateway:
+
+```sh
+# generate a random password
+PASSWORD=$(head -c 12 /dev/urandom | shasum| cut -d' ' -f1)
+
+kubectl -n openfaas create secret generic basic-auth \
+--from-literal=basic-auth-user=admin \
+--from-literal=basic-auth-password="$PASSWORD"
+```
+
+Now decide how you want to expose the services and edit the `helm upgrade` command as required.
+
+* To use NodePorts (default) pass no additional flags
+* To use a LoadBalancer add `--set serviceType=LoadBalancer`
+* To use an IngressController add `--set ingress.enabled=true`
+
+> Note: even without a LoadBalancer or IngressController you can access your gateway at any time via `kubectl port-forward`.
+
+Now deploy OpenFaaS from the helm chart repo:
+
+```sh
+helm repo update \
+ && helm upgrade openfaas --install openfaas/openfaas \
+    --namespace openfaas  \
+    --set basic_auth=true \
+    --set functionNamespace=openfaas-fn
+```
+
+> The above command will also update your helm repo to pull in any new releases.
+
+#### Tuning cold-start
+
+The concept of a cold-start in OpenFaaS only applies if you A) use faas-idler and B) set a specific function to scale to zero.
+
+There are two ways to reduce the Kubernetes cold-start for a pre-pulled image, which is 1-2 seconds.
+
+1) Don't set the function to scale down to zero, just set it a minimum availability i.e. 1/1 replicas
+2) Use async invocations via the `/async/function/<name>` route
+3) Tune the readinessProbes to be aggressively low values. This will reduce the cold-start at the cost of more `kubelet` CPU usage
+
+To achieve around 1s coldstart, set `values.yaml`:
+
+```yaml
+faasnetes:
+
+# redacted
+  readinessProbe:
+    initialDelaySeconds: 0
+    timeoutSeconds: 1
+    periodSeconds: 1
+  livenessProbe:
+    initialDelaySeconds: 0
+    timeoutSeconds: 1
+    periodSeconds: 1
+# redacted
+  imagePullPolicy: "IfNotPresent"    # Image pull policy for deployed functions
+```
+
+You should also set `imagePullPolicy` to `IfNotPresent` so that the `kubelet` only pulls images which are not already available.
+
+#### httpProbe vs. execProbe
+
+A note on health-checking probes for functions:
+
+* httpProbe - (`default`) most efficient. (compatible with Istio >= 1.1.5)
+* execProbe - least efficient option, but compatible with Istio < 1.1.5
+
+Use `--set faasnetes.httpProbe=true/false` to toggle between http / exec probes.
+
+### Verify the installation
+
+Once all the services are up and running, log into your gateway using the OpenFaaS CLI. This will cache your credentials into your `~/.openfaas/config.yml` file.
+
+Fetch your public IP or NodePort via `kubectl get svc -n openfaas gateway-external -o wide` and set it as an environmental variable as below:
+
+```sh
+export OPENFAAS_URL=http://127.0.0.1:31112
+```
+
+If using a remote cluster, you can port-forward the gateway to your local machine:
+
+```sh
+kubectl port-forward -n openfaas svc/gateway 31112:8080 &
+```
+
+Now log in with the CLI and check connectivity:
+
+```sh
+echo -n $PASSWORD | faas-cli login -g $OPENFAAS_URL -u admin --password-stdin
+
+faas-cli version
+```
+
+## OpenFaaS Operator and Function CRD
+
+If you would like to work with Function CRDs there is an alternative controller to faas-netes named [OpenFaaS Operator](https://github.com/openfaas-incubator/openfaas-operator) which can be swapped in at deployment time.
+The OpenFaaS Operator is suitable for development and testing and may replace the faas-netes controller in the future.
+The Operator is compatible with Kubernetes 1.9 or later.
+
+To use it, add the flag: `--set operator.create=true` when installing with Helm.
+
+### faas-netes vs OpenFaaS Operator
+
+The faas-netes controller is the most tested, stable and supported version of the OpenFaaS integration with Kubernetes. In contrast the OpenFaaS Operator is based upon the codebase and features from `faas-netes`, but offers a tighter integration with Kubernetes through [CustomResourceDefinitions](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/). This means you can type in `kubectl get functions` for instance.
+
+See also: [Introducing the OpenFaaS Operator](https://www.openfaas.com/blog/kubernetes-operator-crd/)
+
+## Deployment with `helm template`
+This option is good for those that have issues with installing Tiller, the server/cluster component of helm. Using the `helm` CLI, we can pre-render and then apply the templates using `kubectl`.
+
+1. Clone the faas-netes repository
+    git clone https://github.com/openfaas/faas-netes.git
+
+2. Render the chart to a Kubernetes manifest called `openfaas.yaml`
+    ```
+    helm template faas-netes/chart/openfaas \
+        --name openfaas \
+        --namespace openfaas  \
+        --set basic_auth=true \
+        --set functionNamespace=openfaas-fn > $HOME/openfaas.yaml
+    ```
+    You can set the values and overrides just as you would in the install/upgrade commands above.
+
+3. Install the components using `kubectl`
+    kubectl apply -f faas-netes/namespaces.yml
+    kubectl apply -f $HOME/openfaas.yaml
+
+Now [verify your installation](#verify-the-installation).
+
+## Test a local helm chart
+
+You can run the following command from within the `faas-netes/chart` folder in the `faas-netes` repo.
+
+```sh
+helm upgrade --install openfaas openfaas/ \
+    --namespace openfaas  \
+    --set basic_auth=true \
+    --set functionNamespace=openfaas-fn
+```
+
+## Exposing services
+
+### NodePorts
+
+By default a NodePort will be created for the API Gateway.
+
+### Metrics
+
+You temporarily access the Prometheus metrics by ueing `port-forward`
+
+```
+kubectl --namespace openfaas port-forward deployment/prometheus 31119:9090
+```
+
+Then open `http://localhost:31119` to directly query the OpenFaaS metrics scraped by Prometheus.
+
+### LB
+
+If you're running on a cloud such as AKS or GKE you will need to pass an additional flag of `--set serviceType=LoadBalancer` to tell `helm` to create LoadBalancer objects instead. An alternative to using multiple LoadBalancers is to install an Ingress controller.
+
+### Deploy with an IngressController
+
+In order to make use of automatic ingress settings you will need an IngressController in your cluster such as Traefik or Nginx.
+
+Add `--set ingress.enabled` to enable ingress pass `--set ingress.enabled=true` when running the installation via `helm`.
+
+By default services will be exposed with following hostnames (can be changed, see values.yaml for details):
+
+* `gateway.openfaas.local`
+
+### SSL / TLS
+
+If you require TLS/SSL then please make use of an IngressController. A full guide is provided to [enable TLS for the OpenFaaS Gateway using cert-manager and Let's Encrypt](https://docs.openfaas.com/reference/ssl/kubernetes-with-cert-manager/).
+
+## Zero scale
+
+### Scale-up from zero (on by default)
+
+Scaling up from zero replicas is enabled by default, to turn it off set `scaleFromZero` to `false` in the helm chart options for the `gateway` component.
+
+```sh
+--set gateway.scaleFromZero=true/false
+```
+
+### Scale-down to zero (off by default)
+
+Scaling down to zero replicas can be achieved either through the REST API and your own controller, or by using the [faas-idler](https://github.com/openfaas-incubator/faas-idler) component.
+
+By default the faas-idler is set to only do a dryRun and to not scale any functions down.
+
+```sh
+--set faasIdler.dryRun=true/false
+```
+
+The faas-idler will only scale down functions which have marked themselves as eligible for this behaviour through the use of a label: `com.openfaas.scale.zero=true`.
+
+See also: [faas-idler README](https://docs.openfaas.com/architecture/autoscaling/#zero-scale).
+
+## Configuration
+
+Additional OpenFaaS options in `values.yaml`.
+
+| Parameter               | Description                           | Default                                                    |
+| ----------------------- | ----------------------------------    | ---------------------------------------------------------- |
+| `functionNamespace` | Functions namespace, preferred `openfaas-fn` | `default` |
+| `async` | Deploys NATS | `true` |
+| `exposeServices` | Expose `NodePorts/LoadBalancer`  | `true` |
+| `serviceType` | Type of external service to use `NodePort/LoadBalancer` | `NodePort` |
+| `basic_auth` | Enable basic authentication on the Gateway | `true` |
+| `rbac` | Enable RBAC | `true` |
+| `httpProbe` | Setting to true will use HTTP for readiness and liveness probe on the OpenFaaS system Pods (compatible with Istio >= 1.1.5) | `true` |
+| `securityContext` | Deploy with a `securityContext` set, this can be disabled for use with Istio sidecar injection | `true` |
+| `openfaasImagePullPolicy` | Image pull policy for openfaas components, can change to `IfNotPresent` in offline env | `Always` |
+| `kubernetesDNSDomain` | Domain name of the Kubernetes cluster | `cluster.local` |
+| `operator.create` | Use the OpenFaaS operator CRD controller, default uses faas-netes as the Kubernetes controller | `false` |
+| `operator.createCRD` | Create the CRD for OpenFaaS Function definition | `true` |
+| `ingress.enabled` | Create ingress resources | `false` |
+| `faasnetes.httpProbe` | Use a httpProbe instead of exec | `false` |
+| `faasnetes.readTimeout` | Queue worker read timeout | `60s` |
+| `faasnetes.writeTimeout` | Queue worker write timeout | `60s` |
+| `faasnetes.imagePullPolicy` | Image pull policy for deployed functions | `Always` |
+| `faasnetes.setNonRootUser` | Force all function containers to run with user id `12000` | `false` |
+| `gateway.replicas` | Replicas of the gateway, pick more than `1` for HA | `1` |
+| `gateway.readTimeout` | Queue worker read timeout | `65s` |
+| `gateway.writeTimeout` | Queue worker write timeout | `65s` |
+| `gateway.upstreamTimeout` | Maximum duration of upstream function call, should be lower than `readTimeout`/`writeTimeout` | `60s` |
+| `gateway.scaleFromZero` | Enables an intercepting proxy which will scale any function from 0 replicas to the desired amount | `true` |
+| `gateway.maxIdleConns` | Set max idle connections from gateway to functions | `1024` |
+| `gateway.maxIdleConnsPerHost` | Set max idle connections from gateway to functions per host | `1024` |
+| `queueWorker.replicas` | Replicas of the queue-worker, pick more than `1` for HA | `1` |
+| `queueWorker.ackWait` | Max duration of any async task/request | `60s` |
+| `nats.enableMonitoring` | Enable the NATS monitoring endpoints on port `8222` | `false` |
+| `faasIdler.create` | Create the faasIdler component | `true` |
+| `faasIdler.inactivityDuration` | Duration after which faas-idler will scale function down to 0 | `15m` |
+| `faasIdler.reconcileInterval` | The time between each of reconciliation | `1m` |
+| `faasIdler.dryRun` | When set to false the OpenFaaS API will be called to scale down idle functions, by default this is set to only print in the logs. | `true` |
+| `prometheus.create` | Create the Prometheus component | `true` |
+| `alertmanager.create` | Create the AlertManager component | `true` |
+
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
+See values.yaml for detailed configuration.
+
+## Removing the OpenFaaS
+
+All control plane components can be cleaned up with helm:
+
+```sh
+helm delete --purge openfaas
+```
+
+Follow this by the following to remove all other associated objects:
+
+```sh
+kubectl delete namespace openfaas openfaas-fn
+```
+
+In some cases your additional functions may need to be either deleted before deleting the chart with `faas-cli` or manually deleted using `kubectl delete`.

--- a/src/openfaas/4.4.0/templates/NOTES.txt
+++ b/src/openfaas/4.4.0/templates/NOTES.txt
@@ -1,0 +1,3 @@
+To verify that openfaas has started, run:
+
+  kubectl --namespace={{ .Release.Namespace }} get deployments -l "release={{ .Release.Name }}, app={{ template "openfaas.name" . }}"

--- a/src/openfaas/4.4.0/templates/_helpers.tpl
+++ b/src/openfaas/4.4.0/templates/_helpers.tpl
@@ -1,0 +1,20 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "openfaas.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "openfaas.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}

--- a/src/openfaas/4.4.0/templates/alertmanager-cfg.yaml
+++ b/src/openfaas/4.4.0/templates/alertmanager-cfg.yaml
@@ -1,0 +1,47 @@
+{{- $functionNs := default .Release.Namespace .Values.functionNamespace }}
+{{- if .Values.alertmanager.create }}
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  labels:
+    app: {{ template "openfaas.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: alertmanager-config
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: alertmanager-config
+  namespace: {{ .Release.Namespace | quote }}
+data:
+  alertmanager.yml: |
+    route:
+      group_by: ['alertname', 'cluster', 'service']
+      group_wait: 5s
+      group_interval: 10s
+      repeat_interval: 30s
+      receiver: scale-up
+      routes:
+      - match:
+          service: gateway
+          receiver: scale-up
+          severity: major
+
+    inhibit_rules:
+    - source_match:
+        severity: 'critical'
+      target_match:
+        severity: 'warning'
+      equal: ['alertname', 'cluster', 'service']
+
+    receivers:
+    - name: 'scale-up'
+      webhook_configs:
+        - url: http://gateway.{{ .Release.Namespace }}:8080/system/alert
+          send_resolved: true
+          {{- if .Values.basic_auth }}
+          http_config:
+            basic_auth:
+              username: admin
+              password_file: /var/secrets/basic-auth-password
+          {{- end -}}
+{{- end }}

--- a/src/openfaas/4.4.0/templates/alertmanager-dep.yaml
+++ b/src/openfaas/4.4.0/templates/alertmanager-dep.yaml
@@ -1,0 +1,104 @@
+{{- $functionNs := default .Release.Namespace .Values.functionNamespace }}
+{{- if .Values.alertmanager.create }}
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: {{ template "openfaas.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: alertmanager
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: alertmanager
+  namespace: {{ .Release.Namespace | quote }}
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: alertmanager
+      annotations:
+        sidecar.istio.io/inject: "false"
+        checksum/alertmanager-config: {{ include (print $.Template.BasePath "/alertmanager-cfg.yaml") . | sha256sum | quote  }}
+    spec:
+      containers:
+      - name: alertmanager
+        image: {{ .Values.alertmanager.image }}
+        imagePullPolicy: {{ .Values.openfaasImagePullPolicy }}
+        command:
+          - "alertmanager"
+          - "--config.file=/alertmanager.yml"
+          - "--storage.path=/alertmanager"
+        livenessProbe:
+          {{- if .Values.httpProbe }}
+          httpGet:
+            path: /-/ready
+            port: 9093
+          {{- else }}
+          exec:
+            command:
+            - wget
+            - --quiet
+            - --tries=1
+            - --timeout=30
+            - --spider
+            - http://localhost:9093/-/ready
+          {{- end }}
+          timeoutSeconds: 30
+        readinessProbe:
+          {{- if .Values.httpProbe }}
+          httpGet:
+            path: /-/ready
+            port: 9093
+          {{- else }}
+          exec:
+            command:
+            - wget
+            - --quiet
+            - --tries=1
+            - --timeout=30
+            - --spider
+            - http://localhost:9093/-/ready
+          {{- end }}
+          timeoutSeconds: 30
+        ports:
+        - containerPort: 9093
+          protocol: TCP
+        resources:
+          {{- .Values.alertmanager.resources | toYaml | nindent 12 }}
+        volumeMounts:
+        - mountPath: /alertmanager.yml
+          name: alertmanager-config
+          subPath: alertmanager.yml
+        {{- if .Values.basic_auth }}
+        - name: auth
+          readOnly: true
+          mountPath: "/var/secrets"
+        {{- end }}
+      volumes:
+        - name: alertmanager-config
+          configMap:
+            name: alertmanager-config
+            items:
+              - key: alertmanager.yml
+                path: alertmanager.yml
+                mode: 0644
+        {{- if .Values.basic_auth }}
+        - name: auth
+          secret:
+            secretName: basic-auth
+        {{- end }}
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+{{- end }}

--- a/src/openfaas/4.4.0/templates/alertmanager-svc.yaml
+++ b/src/openfaas/4.4.0/templates/alertmanager-svc.yaml
@@ -1,0 +1,22 @@
+{{- $functionNs := default .Release.Namespace .Values.functionNamespace }}
+{{- if .Values.alertmanager.create }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: {{ template "openfaas.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: alertmanager
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: alertmanager
+  namespace: {{ .Release.Namespace | quote }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: 9093
+      protocol: TCP
+  selector:
+    app: alertmanager
+{{- end }}

--- a/src/openfaas/4.4.0/templates/basic-auth-plugin-dep.yaml
+++ b/src/openfaas/4.4.0/templates/basic-auth-plugin-dep.yaml
@@ -1,0 +1,101 @@
+{{- $functionNs := default .Release.Namespace .Values.functionNamespace }}
+{{- if .Values.basic_auth }}
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: {{ template "openfaas.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: basic-auth-plugin
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: basic-auth-plugin
+  namespace: {{ .Release.Namespace | quote }}
+spec:
+  replicas: {{ .Values.basicAuthPlugin.replicas }}
+  template:
+    metadata:
+      annotations:
+        prometheus.io.scrape: "false"
+      labels:
+        app: basic-auth-plugin
+    spec:
+      {{- if .Values.basic_auth }}
+      volumes:
+      - name: auth
+        secret:
+          secretName: basic-auth
+      {{- end }}
+      containers:
+      - name:  basic-auth-plugin
+        resources:
+          {{- .Values.basicAuthPlugin.resources | toYaml | nindent 12 }}
+        image: {{ .Values.basicAuthPlugin.image }}
+        imagePullPolicy: {{ .Values.openfaasImagePullPolicy }}
+        {{- if .Values.securityContext }}
+        securityContext:
+          readOnlyRootFilesystem: true
+          runAsUser: 10001
+        {{- end }}
+        livenessProbe:
+          {{- if .Values.httpProbe }}
+          httpGet:
+            path: /health
+            port: 8080
+          {{- else }}
+          exec:
+            command:
+            - wget
+            - --quiet
+            - --tries=1
+            - --timeout=5
+            - --spider
+            - http://localhost:8080/health
+          {{- end }}
+          timeoutSeconds: 5
+        readinessProbe:
+          {{- if .Values.httpProbe }}
+          httpGet:
+            path: /health
+            port: 8080
+          {{- else }}
+          exec:
+            command:
+            - wget
+            - --quiet
+            - --tries=1
+            - --timeout=5
+            - --spider
+            - http://localhost:8080/health
+          {{- end }}
+          timeoutSeconds: 5
+        env:
+        {{- if .Values.basic_auth }}
+        - name: secret_mount_path
+          value: "/var/secrets"
+        - name: basic_auth
+          value: "{{ .Values.basic_auth }}"
+        volumeMounts:
+        - name: auth
+          readOnly: true
+          mountPath: "/var/secrets"
+        ports:
+        - name: http
+          containerPort: 8080
+          protocol: TCP
+        {{- end }}
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+
+{{- end }}

--- a/src/openfaas/4.4.0/templates/basic-auth-plugin-svc.yaml
+++ b/src/openfaas/4.4.0/templates/basic-auth-plugin-svc.yaml
@@ -1,0 +1,25 @@
+{{- $functionNs := default .Release.Namespace .Values.functionNamespace }}
+{{- if .Values.basic_auth }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: {{ template "openfaas.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: basic-auth-plugin
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: basic-auth-plugin
+  namespace: {{ .Release.Namespace | quote }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app: basic-auth-plugin
+
+{{- end }}

--- a/src/openfaas/4.4.0/templates/controller-rbac.yaml
+++ b/src/openfaas/4.4.0/templates/controller-rbac.yaml
@@ -1,0 +1,94 @@
+{{- $functionNs := default .Release.Namespace .Values.functionNamespace }}
+{{- if eq .Values.operator.create false }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: {{ template "openfaas.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: faas-controller
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ .Release.Name }}-controller
+  namespace: {{ .Release.Namespace | quote }}
+{{- if .Values.rbac }}
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  labels:
+    app: {{ template "openfaas.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: faas-controller
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ .Release.Name }}-controller
+  namespace: {{ $functionNs | quote }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - delete
+      - update
+  - apiGroups:
+      - extensions
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - delete
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - pods/log
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  labels:
+    app: {{ template "openfaas.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: faas-controller
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ .Release.Name }}-controller
+  namespace: {{ $functionNs | quote }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ .Release.Name }}-controller
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Release.Name }}-controller
+    namespace: {{ .Release.Namespace | quote }}
+{{- end }}
+{{- end }}

--- a/src/openfaas/4.4.0/templates/crd.yaml
+++ b/src/openfaas/4.4.0/templates/crd.yaml
@@ -1,0 +1,52 @@
+{{- $functionNs := default .Release.Namespace .Values.functionNamespace }}
+{{- if .Values.operator.create }}
+{{- if .Values.operator.createCRD }}
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: functions.openfaas.com
+spec:
+  group: openfaas.com
+  version: v1alpha2
+  versions:
+    - name: v1alpha2
+      served: true
+      storage: true
+  names:
+    plural: functions
+    singular: function
+    kind: Function
+    shortNames:
+    - fn
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          required:
+            - name
+            - image
+          properties:
+            name:
+              type: string
+              pattern: "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+            image:
+              type: string
+            limits:
+              properties:
+                cpu:
+                  type: string
+                  pattern: "^[0-9]+(m)"
+                memory:
+                  type: string
+                  pattern: "^[0-9]+(Mi|Gi)"
+            requests:
+              properties:
+                cpu:
+                  type: string
+                  pattern: "^[0-9]+(m)"
+                memory:
+                  type: string
+                  pattern: "^[0-9]+(Mi|Gi)"
+{{- end }}
+{{- end }}

--- a/src/openfaas/4.4.0/templates/faas-idler-dep.yaml
+++ b/src/openfaas/4.4.0/templates/faas-idler-dep.yaml
@@ -1,0 +1,68 @@
+{{- $functionNs := default .Release.Namespace .Values.functionNamespace }}
+{{- if .Values.faasIdler.create }}
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: faas-idler
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    app: {{ template "openfaas.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: faas-idler
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+spec:
+  replicas: {{ .Values.faasIdler.replicas }}
+  template:
+    metadata:
+      annotations:
+        prometheus.io.scrape: "false"
+      labels:
+        app: faas-idler
+    spec:
+      containers:
+        - name: faas-idler
+          resources:
+            {{- .Values.faasIdler.resources | toYaml | nindent 12 }}
+          image: {{ .Values.faasIdler.image }}
+          imagePullPolicy: {{ .Values.openfaasImagePullPolicy }}
+          env:
+            - name: gateway_url
+              value: "http://gateway.{{ .Release.Namespace }}:8080/"
+            - name: prometheus_host
+              value: "prometheus.{{ .Release.Namespace }}"
+            - name: prometheus_port
+              value: "9090"
+            - name: inactivity_duration
+              value: {{ .Values.faasIdler.inactivityDuration }}
+            - name: reconcile_interval
+              value: {{ .Values.faasIdler.reconcileInterval }}
+          command:
+            - /home/app/faas-idler
+            - -dry-run={{ .Values.faasIdler.dryRun }}
+
+{{- if .Values.basic_auth }}
+          volumeMounts:
+            - name: auth
+              readOnly: true
+              mountPath: "/var/secrets/"
+      volumes:
+        - name: auth
+          secret:
+            secretName: basic-auth
+
+{{- end }}
+{{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+{{- end }}
+{{- end }}

--- a/src/openfaas/4.4.0/templates/gateway-dep.yaml
+++ b/src/openfaas/4.4.0/templates/gateway-dep.yaml
@@ -1,0 +1,215 @@
+{{- $functionNs := default .Release.Namespace .Values.functionNamespace }}
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: {{ template "openfaas.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: gateway
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: gateway
+  namespace: {{ .Release.Namespace | quote }}
+spec:
+  replicas: {{ .Values.gateway.replicas }}
+  template:
+    metadata:
+      annotations:
+        prometheus.io.scrape: "true"
+        prometheus.io.port: "8082"
+      labels:
+        app: gateway
+    spec:
+      {{- if .Values.operator.create }}
+      serviceAccountName: {{ .Release.Name }}-operator
+      {{- else }}
+      serviceAccountName: {{ .Release.Name }}-controller
+      {{- end }}
+      {{- if .Values.basic_auth }}
+      volumes:
+      - name: auth
+        secret:
+          secretName: basic-auth
+      {{- end }}
+      containers:
+      - name: gateway
+        resources:
+          {{- .Values.gateway.resources | toYaml | nindent 12 }}
+        image: {{ .Values.gateway.image }}
+        imagePullPolicy: {{ .Values.openfaasImagePullPolicy }}
+        {{- if .Values.securityContext }}
+        securityContext:
+          readOnlyRootFilesystem: true
+          runAsUser: 10001
+        {{- end }}
+        livenessProbe:
+          {{- if .Values.httpProbe }}
+          httpGet:
+            path: /healthz
+            port: 8080
+          {{- else }}
+          exec:
+            command:
+            - wget
+            - --quiet
+            - --tries=1
+            - --timeout=5
+            - --spider
+            - http://localhost:8080/healthz
+          {{- end }}
+          timeoutSeconds: 5
+        readinessProbe:
+          {{- if .Values.httpProbe }}
+          httpGet:
+            path: /healthz
+            port: 8080
+          {{- else }}
+          exec:
+            command:
+            - wget
+            - --quiet
+            - --tries=1
+            - --timeout=5
+            - --spider
+            - http://localhost:8080/healthz
+          {{- end }}
+          timeoutSeconds: 5
+        env:
+        - name: read_timeout
+          value: "{{ .Values.gateway.readTimeout }}"
+        - name: write_timeout
+          value: "{{ .Values.gateway.writeTimeout }}"
+        - name: upstream_timeout
+          value: "{{ .Values.gateway.upstreamTimeout }}"
+        - name: functions_provider_url
+          value: "http://127.0.0.1:8081/"
+        - name: direct_functions
+          value: "true"
+        - name: direct_functions_suffix
+          value: "{{ $functionNs }}.svc.{{ .Values.kubernetesDNSDomain }}"
+        {{- if .Values.async }}
+        - name: faas_nats_address
+          value: "nats.{{ .Release.Namespace }}.svc.{{ .Values.kubernetesDNSDomain }}"
+        - name: faas_nats_port
+          value: "4222"
+        {{- end }}
+        {{- if .Values.basic_auth }}
+        - name: basic_auth
+          value: "true"
+        - name: secret_mount_path
+          value: "/var/secrets"
+        - name: auth_proxy_url
+          value: "http://basic-auth-plugin.{{ .Release.Namespace }}:8080/validate"
+        - name: auth_pass_body
+          value: "false"
+        {{- end }}
+        - name: scale_from_zero
+          value: "{{ .Values.gateway.scaleFromZero }}"
+        - name: max_idle_conns
+          value: "{{ .Values.gateway.maxIdleConns }}"
+        - name: max_idle_conns_per_host
+          value: "{{ .Values.gateway.maxIdleConnsPerHost }}"
+        {{- if .Values.basic_auth }}
+        volumeMounts:
+        - name: auth
+          readOnly: true
+          mountPath: "/var/secrets"
+        {{- end }}
+        ports:
+        - name: http
+          containerPort: 8080
+          protocol: TCP
+      {{- if .Values.operator.create }}
+      - name: operator
+        resources:
+          {{- .Values.operator.resources | toYaml | nindent 12 }}
+        image: {{ .Values.operator.image }}
+        imagePullPolicy: {{ .Values.openfaasImagePullPolicy }}
+        command:
+          - ./openfaas-operator
+          - -logtostderr
+          - -v=2
+        env:
+          - name: port
+            value: "8081"
+          - name: function_namespace
+            value: {{ $functionNs | quote }}
+          - name: read_timeout
+            value: "{{ .Values.faasnetes.readTimeout }}"
+          - name: write_timeout
+            value: "{{ .Values.faasnetes.writeTimeout }}"
+          - name: image_pull_policy
+            value: {{ .Values.faasnetes.imagePullPolicy | quote }}
+          - name: http_probe
+            value: "{{ .Values.faasnetes.httpProbe }}"
+          - name: set_nonroot_user
+            value: "{{ .Values.faasnetes.setNonRootUser }}"
+          - name: readiness_probe_initial_delay_seconds
+            value: "{{ .Values.faasnetes.readinessProbe.initialDelaySeconds }}"
+          - name: readiness_probe_timeout_seconds
+            value: "{{ .Values.faasnetes.readinessProbe.timeoutSeconds }}"
+          - name: readiness_probe_period_seconds
+            value: "{{ .Values.faasnetes.readinessProbe.periodSeconds }}"
+          - name: liveness_probe_initial_delay_seconds
+            value: "{{ .Values.faasnetes.livenessProbe.initialDelaySeconds }}"
+          - name: liveness_probe_timeout_seconds
+            value: "{{ .Values.faasnetes.livenessProbe.timeoutSeconds }}"
+          - name: liveness_probe_period_seconds
+            value: "{{ .Values.faasnetes.livenessProbe.periodSeconds }}"
+        ports:
+        - containerPort: 8081
+          protocol: TCP
+      {{- else }}
+      - name: faas-netes
+        resources:
+          {{- .Values.faasnetes.resources | toYaml | nindent 12 }}
+        image: {{ .Values.faasnetes.image }}
+        imagePullPolicy: {{ .Values.openFaasImagePullPolicy }}
+        {{- if .Values.securityContext }}
+        securityContext:
+          readOnlyRootFilesystem: true
+          runAsUser: 10001
+        {{- end }}
+        env:
+        - name: port
+          value: "8081"
+        - name: function_namespace
+          value: {{ $functionNs | quote }}
+        - name: read_timeout
+          value: "{{ .Values.faasnetes.readTimeout }}"
+        - name: write_timeout
+          value: "{{ .Values.faasnetes.writeTimeout }}"
+        - name: image_pull_policy
+          value: {{ .Values.faasnetes.imagePullPolicy | quote }}
+        - name: http_probe
+          value: "{{ .Values.faasnetes.httpProbe }}"
+        - name: set_nonroot_user
+          value: "{{ .Values.faasnetes.setNonRootUser }}"
+        - name: readiness_probe_initial_delay_seconds
+          value: "{{ .Values.faasnetes.readinessProbe.initialDelaySeconds }}"
+        - name: readiness_probe_timeout_seconds
+          value: "{{ .Values.faasnetes.readinessProbe.timeoutSeconds }}"
+        - name: readiness_probe_period_seconds
+          value: "{{ .Values.faasnetes.readinessProbe.periodSeconds }}"
+        - name: liveness_probe_initial_delay_seconds
+          value: "{{ .Values.faasnetes.livenessProbe.initialDelaySeconds }}"
+        - name: liveness_probe_timeout_seconds
+          value: "{{ .Values.faasnetes.livenessProbe.timeoutSeconds }}"
+        - name: liveness_probe_period_seconds
+          value: "{{ .Values.faasnetes.livenessProbe.periodSeconds }}"
+        ports:
+        - containerPort: 8081
+          protocol: TCP
+      {{- end }}
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}

--- a/src/openfaas/4.4.0/templates/gateway-external-svc.yaml
+++ b/src/openfaas/4.4.0/templates/gateway-external-svc.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.exposeServices }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: {{ template "openfaas.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: gateway
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: gateway-external
+  namespace: {{ .Release.Namespace | quote }}
+spec:
+  type: {{ .Values.serviceType }}
+  ports:
+    - port: 8080
+      protocol: TCP
+      targetPort: 8080
+      {{- if contains "NodePort" .Values.serviceType }}
+      nodePort: {{ .Values.gateway.nodePort }}
+      {{- end }}
+  selector:
+    app: gateway
+  {{- end }}

--- a/src/openfaas/4.4.0/templates/gateway-svc.yaml
+++ b/src/openfaas/4.4.0/templates/gateway-svc.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: {{ template "openfaas.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: gateway
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: gateway
+  namespace: {{ .Release.Namespace | quote }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app: gateway

--- a/src/openfaas/4.4.0/templates/ingress.yaml
+++ b/src/openfaas/4.4.0/templates/ingress.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ template "openfaas.name" . }}-ingress
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    app: {{ template "openfaas.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  annotations:
+    {{- range $key, $value := .Values.ingress.annotations }}
+      {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  rules:
+    {{- range $host := .Values.ingress.hosts }}
+    - host: {{ $host.host }}
+      http:
+        paths:
+          - path: {{ $host.path }}
+            backend:
+              serviceName: {{ $host.serviceName }}
+              servicePort: {{ $host.servicePort }}
+    {{- end -}}
+  {{- if .Values.ingress.tls }}
+  tls:
+{{ toYaml .Values.ingress.tls | indent 4 }}
+  {{- end -}}
+{{- end -}}

--- a/src/openfaas/4.4.0/templates/nats-dep.yaml
+++ b/src/openfaas/4.4.0/templates/nats-dep.yaml
@@ -1,0 +1,58 @@
+{{- if .Values.async }}
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: {{ template "openfaas.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: nats
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: nats
+  namespace: {{ .Release.Namespace | quote }}
+spec:
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+        prometheus.io.scrape: "false"
+      labels:
+        app: nats
+    spec:
+      containers:
+      - name:  nats
+        resources:
+          {{- .Values.nats.resources | toYaml | nindent 12 }}
+        image: {{ .Values.nats.image }}
+        imagePullPolicy: {{ .Values.openfaasImagePullPolicy }}
+        ports:
+        - containerPort: 4222
+          protocol: TCP
+        {{- if .Values.nats.enableMonitoring }}
+        - containerPort: 8222
+          protocol: TCP
+        {{- end }}
+        command: ["/nats-streaming-server"]
+        args:
+          - --store
+          - memory
+          - --cluster_id
+          - faas-cluster
+          {{- if .Values.nats.enableMonitoring }}
+          - -m
+          - "8222"
+          {{- end }}
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+{{- end }}

--- a/src/openfaas/4.4.0/templates/nats-svc.yaml
+++ b/src/openfaas/4.4.0/templates/nats-svc.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.async }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: {{ template "openfaas.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: nats
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: nats
+  namespace: {{ .Release.Namespace | quote }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: 4222
+      protocol: TCP
+      name: clients
+    {{- if .Values.nats.enableMonitoring }}
+    - port: 8222
+      protocol: TCP
+      name: monitoring
+    {{- end }}
+  selector:
+    app: nats
+{{- end }}

--- a/src/openfaas/4.4.0/templates/operator-rbac.yaml
+++ b/src/openfaas/4.4.0/templates/operator-rbac.yaml
@@ -1,0 +1,65 @@
+{{- $functionNs := default .Release.Namespace .Values.functionNamespace }}
+{{- if .Values.operator.create }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Release.Name }}-operator
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    app: {{ template "openfaas.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: openfaas-operator
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+{{- if .Values.rbac }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .Release.Name }}-operator-rw
+  namespace: {{ $functionNs | quote }}
+  labels:
+    app: {{ template "openfaas.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: openfaas-operator
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+rules:
+- apiGroups: ["openfaas.com"]
+  resources: ["functions"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+- apiGroups: [""]
+  resources: ["services"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+- apiGroups: ["apps", "extensions"]
+  resources: ["deployments"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Release.Name }}-operator-rw
+  namespace: {{ $functionNs | quote }}
+  labels:
+    app: {{ template "openfaas.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: openfaas-operator
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ .Release.Name }}-operator-rw
+subjects:
+- kind: ServiceAccount
+  name: {{ .Release.Name }}-operator
+  namespace: {{ .Release.Namespace | quote }}
+{{- end }}
+{{- end }}

--- a/src/openfaas/4.4.0/templates/prometheus-cfg.yaml
+++ b/src/openfaas/4.4.0/templates/prometheus-cfg.yaml
@@ -1,0 +1,79 @@
+{{- $functionNs := default .Release.Namespace .Values.functionNamespace }}
+{{- if .Values.prometheus.create }}
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  labels:
+    app: {{ template "openfaas.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: prometheus-config
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: prometheus-config
+  namespace: {{ .Release.Namespace | quote }}
+data:
+  prometheus.yml: |
+    global:
+      scrape_interval:     15s
+      evaluation_interval: 15s
+      external_labels:
+          monitor: 'faas-monitor'
+
+    rule_files:
+        - 'alert.rules.yml'
+
+    scrape_configs:
+      - job_name: 'prometheus'
+        scrape_interval: 5s
+        static_configs:
+          - targets: ['localhost:9090']
+
+      - job_name: 'kubernetes-pods'
+        scrape_interval: 5s
+        honor_labels: false
+        kubernetes_sd_configs:
+          - role: pod
+            namespaces:
+              names:
+                - {{ .Release.Namespace }}
+        relabel_configs:
+        - action: labelmap
+          regex: __meta_kubernetes_pod_label_(.+)
+        - source_labels: [__meta_kubernetes_namespace]
+          action: replace
+          target_label: kubernetes_namespace
+        - source_labels: [__meta_kubernetes_pod_name]
+          action: replace
+          target_label: kubernetes_pod_name
+        - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+          action: keep
+          regex: true
+        - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+          action: replace
+          regex: ([^:]+)(?::\d+)?;(\d+)
+          replacement: $1:$2
+          target_label: __address__
+
+    alerting:
+      alertmanagers:
+      - static_configs:
+        - targets:
+          - alertmanager:9093
+
+  alert.rules.yml: |
+    groups:
+      - name: openfaas
+        rules:
+        - alert: service_down
+          expr: up == 0
+        - alert: APIHighInvocationRate
+          expr: sum(rate(gateway_function_invocation_total{code="200"}[10s])) BY (function_name) > 5
+          for: 5s
+          labels:
+            service: gateway
+            severity: major
+          annotations:
+            description: High invocation total on "{{ "{{" }}$labels.function_name{{ "}}" }}"
+            summary: High invocation total on "{{ "{{" }}$labels.function_name{{ "}}" }}"
+{{- end }}

--- a/src/openfaas/4.4.0/templates/prometheus-dep.yaml
+++ b/src/openfaas/4.4.0/templates/prometheus-dep.yaml
@@ -1,0 +1,105 @@
+{{- $functionNs := default .Release.Namespace .Values.functionNamespace }}
+{{- if .Values.prometheus.create }}
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: {{ template "openfaas.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: prometheus
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: prometheus
+  namespace: {{ .Release.Namespace | quote }}
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: prometheus
+      annotations:
+        sidecar.istio.io/inject: "false"
+        checksum/prometheus-config: {{ include (print $.Template.BasePath "/prometheus-cfg.yaml") . | sha256sum | quote }}
+    spec:
+      serviceAccountName: {{ .Release.Name }}-prometheus
+      containers:
+      - name: prometheus
+        resources:
+          {{- .Values.prometheus.resources | toYaml | nindent 12 }}
+        image: {{ .Values.prometheus.image }}
+        command:
+          - "prometheus"
+          - "--config.file=/etc/prometheus/prometheus.yml"
+        imagePullPolicy: {{ .Values.openfaasImagePullPolicy }}
+        livenessProbe:
+          {{- if .Values.httpProbe }}
+          httpGet:
+            path: /-/healthy
+            port: 9090
+          {{- else }}
+          exec:
+            command:
+            - wget
+            - --quiet
+            - --tries=1
+            - --timeout=30
+            - --spider
+            - http://localhost:9090/-/healthy
+          {{- end }}
+          timeoutSeconds: 30
+        readinessProbe:
+          {{- if .Values.httpProbe }}
+          httpGet:
+            path: /-/healthy
+            port: 9090
+          {{- else }}
+          exec:
+            command:
+            - wget
+            - --quiet
+            - --tries=1
+            - --timeout=30
+            - --spider
+            - http://localhost:9090/-/healthy
+          {{- end }}
+          timeoutSeconds: 30
+        ports:
+        - containerPort: 9090
+          protocol: TCP
+        volumeMounts:
+        - mountPath: /etc/prometheus/prometheus.yml
+          name: prometheus-config
+          subPath: prometheus.yml
+        - mountPath: /etc/prometheus/alert.rules.yml
+          name: prometheus-config
+          subPath: alert.rules.yml
+        - mountPath: /prometheus/data
+          name: prom-data
+      volumes:
+        - name: prometheus-config
+          configMap:
+            name: prometheus-config
+            items:
+              - key: prometheus.yml
+                path: prometheus.yml
+                mode: 0644
+              - key: alert.rules.yml
+                path: alert.rules.yml
+                mode: 0644
+        - name: prom-data
+          emptyDir: {}
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+
+{{- end }}

--- a/src/openfaas/4.4.0/templates/prometheus-rbac.yaml
+++ b/src/openfaas/4.4.0/templates/prometheus-rbac.yaml
@@ -1,0 +1,54 @@
+{{- $functionNs := default .Release.Namespace .Values.functionNamespace }}
+{{- if .Values.prometheus.create }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Release.Name }}-prometheus
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    app: {{ template "openfaas.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: prometheus
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .Release.Name }}-prometheus
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    app: {{ template "openfaas.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: prometheus
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+rules:
+- apiGroups: [""]
+  resources:
+    - services
+    - endpoints
+    - pods
+  verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Release.Name }}-prometheus
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    app: {{ template "openfaas.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: prometheus
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ .Release.Name }}-prometheus
+subjects:
+- kind: ServiceAccount
+  name: {{ .Release.Name }}-prometheus
+  namespace: {{ .Release.Namespace | quote }}
+{{- end }}

--- a/src/openfaas/4.4.0/templates/prometheus-svc.yaml
+++ b/src/openfaas/4.4.0/templates/prometheus-svc.yaml
@@ -1,0 +1,22 @@
+{{- $functionNs := default .Release.Namespace .Values.functionNamespace }}
+{{- if .Values.prometheus.create }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: {{ template "openfaas.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: prometheus
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: prometheus
+  namespace: {{ .Release.Namespace | quote }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: 9090
+      protocol: TCP
+  selector:
+    app: prometheus
+{{- end }}

--- a/src/openfaas/4.4.0/templates/queueworker-dep.yaml
+++ b/src/openfaas/4.4.0/templates/queueworker-dep.yaml
@@ -1,0 +1,69 @@
+{{- if .Values.async }}
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: {{ template "openfaas.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: queue-worker
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: queue-worker
+  namespace: {{ .Release.Namespace | quote }}
+spec:
+  replicas: {{ .Values.queueWorker.replicas }}
+  template:
+    metadata:
+      annotations:
+        prometheus.io.scrape: "false"
+      labels:
+        app: queue-worker
+    spec:
+      {{- if .Values.basic_auth }}
+      volumes:
+      - name: auth
+        secret:
+          secretName: basic-auth
+      {{- end }}
+      containers:
+      - name:  queue-worker
+        resources:
+          {{- .Values.queueWorker.resources | toYaml | nindent 12 }}
+        image: {{ .Values.queueWorker.image }}
+        imagePullPolicy: {{ .Values.openfaasImagePullPolicy }}
+        env:
+        - name: faas_nats_address
+          value: "nats.{{ .Release.Namespace }}.svc.{{ .Values.kubernetesDNSDomain }}"
+        - name: faas_gateway_address
+          value: "gateway.{{ .Release.Namespace }}.svc.{{ .Values.kubernetesDNSDomain }}"
+        - name: "gateway_invoke"
+          value: "{{ .Values.queueWorker.gatewayInvoke }}"
+        {{- if .Values.functionNamespace }}
+        - name: faas_function_suffix
+          value: ".{{ .Values.functionNamespace }}.svc.{{ .Values.kubernetesDNSDomain }}"
+        {{- end }}
+        - name: ack_wait    # Max duration of any async task / request
+          value: {{ .Values.queueWorker.ackWait }}
+        {{- if .Values.basic_auth }}
+        - name: secret_mount_path
+          value: "/var/secrets"
+        - name: basic_auth
+          value: "{{ .Values.basic_auth }}"
+        volumeMounts:
+        - name: auth
+          readOnly: true
+          mountPath: "/var/secrets"
+        {{- end }}
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+{{- end }}

--- a/src/openfaas/4.4.0/values-arm64.yaml
+++ b/src/openfaas/4.4.0/values-arm64.yaml
@@ -1,0 +1,19 @@
+basic_auth: true
+
+faasnetes:
+  image: openfaas/faas-netes:0.8.0-arm64
+
+gateway:
+  image: openfaas/gateway:0.14.4-arm64
+
+queueWorker:
+  image: openfaas/queue-worker:0.7.1-arm64
+
+prometheus:
+  image: functions/prometheus:2.7.1-arm64
+
+alertmanager:
+  image: functions/alertmanager:0.16.1-arm64
+
+faasIdler:
+  image: openfaas/faas-idler:0.2.0-arm64

--- a/src/openfaas/4.4.0/values-armhf.yaml
+++ b/src/openfaas/4.4.0/values-armhf.yaml
@@ -1,0 +1,26 @@
+basic_auth: false
+
+faasnetes:
+  image: openfaas/faas-netes:0.8.0-armhf
+
+gateway:
+  image: openfaas/gateway:0.14.4-armhf
+
+queueWorker:
+  image: openfaas/queue-worker:0.4.9-armhf
+
+prometheus:
+  image: functions/prometheus:2.7.1-armhf
+  resources:
+    requests:
+      memory: "125Mi"
+
+alertmanager:
+  image: functions/alertmanager:0.16.1-armhf
+
+faasIdler:
+  image: openfaas/faas-idler:0.2.0-armhf
+
+basicAuthPlugin:
+  image: openfaas/basic-auth-plugin:0.14.4-armhf
+  replicas: 1

--- a/src/openfaas/4.4.0/values.yaml
+++ b/src/openfaas/4.4.0/values.yaml
@@ -1,0 +1,139 @@
+functionNamespace: openfaas-fn
+
+async: true
+
+exposeServices: true
+serviceType: LoadBalancer
+httpProbe: true               # Setting to true will use HTTP for readiness and liveness probe on the OpenFaaS system Pods (incompatible with Istio < 1.1.5)
+rbac: true
+securityContext: true
+basic_auth: true
+
+# image pull policy for openfaas components, can change to `IfNotPresent` in offline env
+openfaasImagePullPolicy: "Always"
+
+gateway:
+  image: openfaas/gateway:0.15.0
+  readTimeout : "65s"
+  writeTimeout : "65s"
+  upstreamTimeout : "60s"  # Must be smaller than read/write_timeout
+  replicas: 1
+  scaleFromZero: true
+  # change the port when creating multiple releases in the same baremetal cluster
+  nodePort: 31112
+  maxIdleConns: 1024
+  maxIdleConnsPerHost: 1024
+  resources:
+    requests:
+      memory: "120Mi"
+      cpu: "50m"
+
+faasnetes:
+  image: openfaas/faas-netes:0.8.1
+  readTimeout : "60s"
+  writeTimeout : "60s"
+  imagePullPolicy : "Always"    # Image pull policy for deployed functions
+  httpProbe: true               # Setting to true will use HTTP for readiness and liveness probe on Pods (incompatible with Istio < 1.1.5)
+  setNonRootUser: false
+  readinessProbe:
+    initialDelaySeconds: 2
+    timeoutSeconds: 1           # Tuned-in to run checks early and quickly to support fast cold-start from zero replicas
+    periodSeconds: 2            # Reduce to 1 for a faster cold-start, increase higher for lower-CPU usage
+  livenessProbe:
+    initialDelaySeconds: 2
+    timeoutSeconds: 1
+    periodSeconds: 2           # Reduce to 1 for a faster cold-start, increase higher for lower-CPU usage
+  resources:
+    requests:
+      memory: "120Mi"
+      cpu: "50m"
+
+# replaces faas-netes with openfaas-operator
+operator:
+  image: openfaas/openfaas-operator:0.9.7
+  create: false
+  # set this to false when creating multiple releases in the same cluster
+  # must be true for the first one only
+  createCRD: true
+  resources:
+    requests:
+      memory: "120Mi"
+      cpu: "50m"
+
+queueWorker:
+  image: openfaas/queue-worker:0.7.2
+  ackWait : "60s"
+  replicas: 1
+  gatewayInvoke: true
+  resources:
+    requests:
+      memory: "120Mi"
+      cpu: "50m"
+
+# monitoring and auto-scaling components
+# both components
+prometheus:
+  image: prom/prometheus:v2.7.1
+  create: true
+  resources:
+    requests:
+      memory: "512Mi"
+
+alertmanager:
+  image: prom/alertmanager:v0.16.1
+  create: true
+  resources:
+    requests:
+      memory: "25Mi"
+    limits:
+      memory: "50Mi"
+
+# async provider
+nats:
+  image: nats-streaming:0.11.2
+  enableMonitoring: false
+  resources:
+    requests:
+      memory: "120Mi"
+
+# ingress configuration
+ingress:
+  enabled: false
+  # Used to create Ingress record (should be used with exposeServices: false).
+  hosts:
+    - host: gateway.openfaas.local  # Replace with gateway.example.com if public-facing
+      serviceName: gateway
+      servicePort: 8080
+      path: /
+  annotations:
+    kubernetes.io/ingress.class: nginx
+  tls:
+    # Secrets must be manually created in the namespace.
+
+# faas-idler configuration
+faasIdler:
+  image: openfaas/faas-idler:0.1.9
+  replicas: 1
+  create: true
+  inactivityDuration: 15m               # If a function is inactive for 15 minutes, it may be scaled to zero
+  reconcileInterval: 1m                 # The interval between each attempt to scale functions to zero
+  dryRun: true                          # Set to false to enable the idler to apply changes and scale to zero
+  resources:
+    requests:
+      memory: "64Mi"
+
+basicAuthPlugin:
+  image: openfaas/basic-auth-plugin:0.1.1
+  replicas: 1
+  resources:
+    requests:
+      memory: "50Mi"
+      cpu: "20m"
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+kubernetesDNSDomain: cluster.local

--- a/src/openfaas/4.4.0/values.yamle
+++ b/src/openfaas/4.4.0/values.yamle
@@ -1,0 +1,139 @@
+functionNamespace: openfaas-fn
+
+async: true
+
+exposeServices: true
+serviceType: NodePort
+httpProbe: true               # Setting to true will use HTTP for readiness and liveness probe on the OpenFaaS system Pods (incompatible with Istio < 1.1.5)
+rbac: true
+securityContext: true
+basic_auth: true
+
+# image pull policy for openfaas components, can change to `IfNotPresent` in offline env
+openfaasImagePullPolicy: "Always"
+
+gateway:
+  image: openfaas/gateway:0.15.0
+  readTimeout : "65s"
+  writeTimeout : "65s"
+  upstreamTimeout : "60s"  # Must be smaller than read/write_timeout
+  replicas: 1
+  scaleFromZero: true
+  # change the port when creating multiple releases in the same baremetal cluster
+  nodePort: 31112
+  maxIdleConns: 1024
+  maxIdleConnsPerHost: 1024
+  resources:
+    requests:
+      memory: "120Mi"
+      cpu: "50m"
+
+faasnetes:
+  image: openfaas/faas-netes:0.8.1
+  readTimeout : "60s"
+  writeTimeout : "60s"
+  imagePullPolicy : "Always"    # Image pull policy for deployed functions
+  httpProbe: true               # Setting to true will use HTTP for readiness and liveness probe on Pods (incompatible with Istio < 1.1.5)
+  setNonRootUser: false
+  readinessProbe:
+    initialDelaySeconds: 2
+    timeoutSeconds: 1           # Tuned-in to run checks early and quickly to support fast cold-start from zero replicas
+    periodSeconds: 2            # Reduce to 1 for a faster cold-start, increase higher for lower-CPU usage
+  livenessProbe:
+    initialDelaySeconds: 2
+    timeoutSeconds: 1
+    periodSeconds: 2           # Reduce to 1 for a faster cold-start, increase higher for lower-CPU usage
+  resources:
+    requests:
+      memory: "120Mi"
+      cpu: "50m"
+
+# replaces faas-netes with openfaas-operator
+operator:
+  image: openfaas/openfaas-operator:0.9.7
+  create: false
+  # set this to false when creating multiple releases in the same cluster
+  # must be true for the first one only
+  createCRD: true
+  resources:
+    requests:
+      memory: "120Mi"
+      cpu: "50m"
+
+queueWorker:
+  image: openfaas/queue-worker:0.7.2
+  ackWait : "60s"
+  replicas: 1
+  gatewayInvoke: true
+  resources:
+    requests:
+      memory: "120Mi"
+      cpu: "50m"
+
+# monitoring and auto-scaling components
+# both components
+prometheus:
+  image: prom/prometheus:v2.7.1
+  create: true
+  resources:
+    requests:
+      memory: "512Mi"
+
+alertmanager:
+  image: prom/alertmanager:v0.16.1
+  create: true
+  resources:
+    requests:
+      memory: "25Mi"
+    limits:
+      memory: "50Mi"
+
+# async provider
+nats:
+  image: nats-streaming:0.11.2
+  enableMonitoring: false
+  resources:
+    requests:
+      memory: "120Mi"
+
+# ingress configuration
+ingress:
+  enabled: false
+  # Used to create Ingress record (should be used with exposeServices: false).
+  hosts:
+    - host: gateway.openfaas.local  # Replace with gateway.example.com if public-facing
+      serviceName: gateway
+      servicePort: 8080
+      path: /
+  annotations:
+    kubernetes.io/ingress.class: nginx
+  tls:
+    # Secrets must be manually created in the namespace.
+
+# faas-idler configuration
+faasIdler:
+  image: openfaas/faas-idler:0.1.9
+  replicas: 1
+  create: true
+  inactivityDuration: 15m               # If a function is inactive for 15 minutes, it may be scaled to zero
+  reconcileInterval: 1m                 # The interval between each attempt to scale functions to zero
+  dryRun: true                          # Set to false to enable the idler to apply changes and scale to zero
+  resources:
+    requests:
+      memory: "64Mi"
+
+basicAuthPlugin:
+  image: openfaas/basic-auth-plugin:0.1.1
+  replicas: 1
+  resources:
+    requests:
+      memory: "50Mi"
+      cpu: "20m"
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+kubernetesDNSDomain: cluster.local

--- a/src/openfaas/README.md
+++ b/src/openfaas/README.md
@@ -1,0 +1,30 @@
+## Generate the OpenFaaS helm Chart
+
+```
+export APP_NAME="openfaas"
+export HELM_CHART_NAME="openfaas"
+export HELM_CHART_VERSION="4.4.0"
+export $HELM_REPO="openfaas/"
+
+helm repo update
+
+mkdir src/$APP_NAME
+cd src/$APP_NAME
+helm fetch --version $HELM_CHART_VERSION --untar $HELM_REPO$HELM_CHART_NAME
+mv $APP_NAME $HELM_CHART_VERSION
+```
+
+Enable the `LoadBalancer`
+
+```
+sed -ie s/serviceType:\ NodePort/serviceType:\ LoadBalancer/ 4.4.0/values.yaml
+```
+
+```
+rm -rf ../stacks/openfaas
+cd utils
+STACK_NAME=$APP_NAME ./generate-stack.sh
+
+cd ..
+./stacks/$APP_NAME/render.sh
+```

--- a/src/openfaas/README.md
+++ b/src/openfaas/README.md
@@ -4,7 +4,9 @@
 export APP_NAME="openfaas"
 export HELM_CHART_NAME="openfaas"
 export HELM_CHART_VERSION="4.4.0"
-export $HELM_REPO="openfaas/"
+export HELM_REPO="openfaas/"
+
+helm repo add openfaas https://openfaas.github.io/faas-netes/
 
 helm repo update
 
@@ -14,10 +16,10 @@ helm fetch --version $HELM_CHART_VERSION --untar $HELM_REPO$HELM_CHART_NAME
 mv $APP_NAME $HELM_CHART_VERSION
 ```
 
-Enable the `LoadBalancer`
+Enable the `LoadBalancer` in `values.yaml`:
 
 ```
-sed -ie s/serviceType:\ NodePort/serviceType:\ LoadBalancer/ 4.4.0/values.yaml
+sed -ie s/serviceType:\ NodePort/serviceType:\ LoadBalancer/ ${HELM_CHART_VERSION}/values.yaml
 ```
 
 ```

--- a/src/openfaas/README.md
+++ b/src/openfaas/README.md
@@ -30,3 +30,21 @@ STACK_NAME=$APP_NAME ./generate-stack.sh
 cd ..
 ./stacks/$APP_NAME/render.sh
 ```
+
+## Get your gateway URL and password
+
+```
+kubectl get secret -n openfaas basic-auth -o jsonpath="{.data.basic-auth-password}" | base64 --decode > password.txt
+
+export OPENFAAS_URL=$(kubectl get svc -n openfaas gateway-external -o  jsonpath='{.status.loadBalancer.ingress[*].ip}'):8080
+
+echo "Your gateway URL is: ${OPENFAAS_URL}"
+
+cat password.txt | faas-cli login --username admin --password-stdin
+
+faas-cli store deploy nodeinfo
+
+faas-cli list -v
+
+faas-cli describe nodeinfo
+```

--- a/stacks/openfaas/deploy-local.sh
+++ b/stacks/openfaas/deploy-local.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+set -e
+
+ROOT_DIR=$(git rev-parse --show-toplevel)
+
+kubectl apply -f https://raw.githubusercontent.com/openfaas/faas-netes/master/namespaces.yml
+
+# set kubectl namespace
+kubectl config set-context --current --namespace=openfaas
+
+# deploy openfaas
+kubectl apply -f "$ROOT_DIR"/stacks/openfaas/yaml/openfaas.yaml
+
+# ensure services are running
+kubectl rollout status -n openfaas deployment/gateway

--- a/stacks/openfaas/deploy-local.sh
+++ b/stacks/openfaas/deploy-local.sh
@@ -6,6 +6,13 @@ ROOT_DIR=$(git rev-parse --show-toplevel)
 
 kubectl apply -f https://raw.githubusercontent.com/openfaas/faas-netes/master/namespaces.yml
 
+# generate a random password
+PASSWORD=$(head -c 12 /dev/urandom | shasum| cut -d' ' -f1)
+
+kubectl -n openfaas create secret generic basic-auth \
+--from-literal=basic-auth-user=admin \
+--from-literal=basic-auth-password="$PASSWORD"
+
 # set kubectl namespace
 kubectl config set-context --current --namespace=openfaas
 

--- a/stacks/openfaas/deploy.sh
+++ b/stacks/openfaas/deploy.sh
@@ -4,6 +4,13 @@ set -e
 
 kubectl apply -f https://raw.githubusercontent.com/openfaas/faas-netes/master/namespaces.yml
 
+# generate a random password
+PASSWORD=$(head -c 12 /dev/urandom | shasum| cut -d' ' -f1)
+
+kubectl -n openfaas create secret generic basic-auth \
+--from-literal=basic-auth-user=admin \
+--from-literal=basic-auth-password="$PASSWORD"
+
 # set kubectl namespace
 kubectl config set-context --current --namespace=openfaas
 

--- a/stacks/openfaas/deploy.sh
+++ b/stacks/openfaas/deploy.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+set -e
+
+kubectl apply -f https://raw.githubusercontent.com/openfaas/faas-netes/master/namespaces.yml
+
+# set kubectl namespace
+kubectl config set-context --current --namespace=openfaas
+
+# deploy openfaas
+kubectl apply -f https://raw.githubusercontent.com/digitalocean/marketplace-kubernetes/master/stacks/openfaas/yaml/openfaas.yaml
+
+# ensure services are running
+kubectl rollout status -n openfaas deployment/gateway

--- a/stacks/openfaas/render.sh
+++ b/stacks/openfaas/render.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+set -e
+
+BUILD_DIR=$(mktemp -d)
+ROOT_DIR=$(git rev-parse --show-toplevel)
+
+SRC_VERSION="4.4.0"
+
+cp -r "$ROOT_DIR"/src/openfaas/"$SRC_VERSION" $BUILD_DIR
+cp -r "$ROOT_DIR"/stacks/openfaas $BUILD_DIR
+
+cd $BUILD_DIR
+
+# Remove test templates
+find "$SRC_VERSION" -type d -name tests -print0 | xargs -0 rm -rf
+
+# Create YAML directory
+rm -rf "$ROOT_DIR"/stacks/openfaas/yaml
+mkdir -p "$ROOT_DIR"/stacks/openfaas/yaml
+
+# render openfaas
+helm template \
+  --name openfaas \
+  --namespace openfaas \
+  --values "$ROOT_DIR"/src/openfaas/4.4.0/values.yaml \
+  "$SRC_VERSION" > "$ROOT_DIR"/stacks/openfaas/yaml/openfaas.yaml

--- a/stacks/openfaas/yaml/openfaas.yaml
+++ b/stacks/openfaas/yaml/openfaas.yaml
@@ -1,0 +1,911 @@
+---
+# Source: openfaas/templates/alertmanager-cfg.yaml
+
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  labels:
+    app: openfaas
+    chart: openfaas-4.4.0
+    component: alertmanager-config
+    heritage: Tiller
+    release: openfaas
+  name: alertmanager-config
+  namespace: "openfaas"
+data:
+  alertmanager.yml: |
+    route:
+      group_by: ['alertname', 'cluster', 'service']
+      group_wait: 5s
+      group_interval: 10s
+      repeat_interval: 30s
+      receiver: scale-up
+      routes:
+      - match:
+          service: gateway
+          receiver: scale-up
+          severity: major
+
+    inhibit_rules:
+    - source_match:
+        severity: 'critical'
+      target_match:
+        severity: 'warning'
+      equal: ['alertname', 'cluster', 'service']
+
+    receivers:
+    - name: 'scale-up'
+      webhook_configs:
+        - url: http://gateway.openfaas:8080/system/alert
+          send_resolved: true
+          http_config:
+            basic_auth:
+              username: admin
+              password_file: /var/secrets/basic-auth-password
+---
+# Source: openfaas/templates/prometheus-cfg.yaml
+
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  labels:
+    app: openfaas
+    chart: openfaas-4.4.0
+    component: prometheus-config
+    heritage: Tiller
+    release: openfaas
+  name: prometheus-config
+  namespace: "openfaas"
+data:
+  prometheus.yml: |
+    global:
+      scrape_interval:     15s
+      evaluation_interval: 15s
+      external_labels:
+          monitor: 'faas-monitor'
+
+    rule_files:
+        - 'alert.rules.yml'
+
+    scrape_configs:
+      - job_name: 'prometheus'
+        scrape_interval: 5s
+        static_configs:
+          - targets: ['localhost:9090']
+
+      - job_name: 'kubernetes-pods'
+        scrape_interval: 5s
+        honor_labels: false
+        kubernetes_sd_configs:
+          - role: pod
+            namespaces:
+              names:
+                - openfaas
+        relabel_configs:
+        - action: labelmap
+          regex: __meta_kubernetes_pod_label_(.+)
+        - source_labels: [__meta_kubernetes_namespace]
+          action: replace
+          target_label: kubernetes_namespace
+        - source_labels: [__meta_kubernetes_pod_name]
+          action: replace
+          target_label: kubernetes_pod_name
+        - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+          action: keep
+          regex: true
+        - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+          action: replace
+          regex: ([^:]+)(?::\d+)?;(\d+)
+          replacement: $1:$2
+          target_label: __address__
+
+    alerting:
+      alertmanagers:
+      - static_configs:
+        - targets:
+          - alertmanager:9093
+
+  alert.rules.yml: |
+    groups:
+      - name: openfaas
+        rules:
+        - alert: service_down
+          expr: up == 0
+        - alert: APIHighInvocationRate
+          expr: sum(rate(gateway_function_invocation_total{code="200"}[10s])) BY (function_name) > 5
+          for: 5s
+          labels:
+            service: gateway
+            severity: major
+          annotations:
+            description: High invocation total on "{{$labels.function_name}}"
+            summary: High invocation total on "{{$labels.function_name}}"
+---
+# Source: openfaas/templates/controller-rbac.yaml
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: openfaas
+    chart: openfaas-4.4.0
+    component: faas-controller
+    heritage: Tiller
+    release: openfaas
+  name: openfaas-controller
+  namespace: "openfaas"
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  labels:
+    app: openfaas
+    chart: openfaas-4.4.0
+    component: faas-controller
+    heritage: Tiller
+    release: openfaas
+  name: openfaas-controller
+  namespace: "openfaas-fn"
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - delete
+      - update
+  - apiGroups:
+      - extensions
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - delete
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - pods/log
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  labels:
+    app: openfaas
+    chart: openfaas-4.4.0
+    component: faas-controller
+    heritage: Tiller
+    release: openfaas
+  name: openfaas-controller
+  namespace: "openfaas-fn"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: openfaas-controller
+subjects:
+  - kind: ServiceAccount
+    name: openfaas-controller
+    namespace: "openfaas"
+
+---
+# Source: openfaas/templates/prometheus-rbac.yaml
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: openfaas-prometheus
+  namespace: "openfaas"
+  labels:
+    app: openfaas
+    chart: openfaas-4.4.0
+    component: prometheus
+    heritage: Tiller
+    release: openfaas
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: openfaas-prometheus
+  namespace: "openfaas"
+  labels:
+    app: openfaas
+    chart: openfaas-4.4.0
+    component: prometheus
+    heritage: Tiller
+    release: openfaas
+rules:
+- apiGroups: [""]
+  resources:
+    - services
+    - endpoints
+    - pods
+  verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: openfaas-prometheus
+  namespace: "openfaas"
+  labels:
+    app: openfaas
+    chart: openfaas-4.4.0
+    component: prometheus
+    heritage: Tiller
+    release: openfaas
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: openfaas-prometheus
+subjects:
+- kind: ServiceAccount
+  name: openfaas-prometheus
+  namespace: "openfaas"
+---
+# Source: openfaas/templates/alertmanager-svc.yaml
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: openfaas
+    chart: openfaas-4.4.0
+    component: alertmanager
+    heritage: Tiller
+    release: openfaas
+  name: alertmanager
+  namespace: "openfaas"
+spec:
+  type: ClusterIP
+  ports:
+    - port: 9093
+      protocol: TCP
+  selector:
+    app: alertmanager
+---
+# Source: openfaas/templates/basic-auth-plugin-svc.yaml
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: openfaas
+    chart: openfaas-4.4.0
+    component: basic-auth-plugin
+    heritage: Tiller
+    release: openfaas
+  name: basic-auth-plugin
+  namespace: "openfaas"
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app: basic-auth-plugin
+---
+# Source: openfaas/templates/gateway-external-svc.yaml
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: openfaas
+    chart: openfaas-4.4.0
+    component: gateway
+    heritage: Tiller
+    release: openfaas
+  name: gateway-external
+  namespace: "openfaas"
+spec:
+  type: LoadBalancer
+  ports:
+    - port: 8080
+      protocol: TCP
+      targetPort: 8080
+  selector:
+    app: gateway
+---
+# Source: openfaas/templates/gateway-svc.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: openfaas
+    chart: openfaas-4.4.0
+    component: gateway
+    heritage: Tiller
+    release: openfaas
+  name: gateway
+  namespace: "openfaas"
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app: gateway
+
+---
+# Source: openfaas/templates/nats-svc.yaml
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: openfaas
+    chart: openfaas-4.4.0
+    component: nats
+    heritage: Tiller
+    release: openfaas
+  name: nats
+  namespace: "openfaas"
+spec:
+  type: ClusterIP
+  ports:
+    - port: 4222
+      protocol: TCP
+      name: clients
+  selector:
+    app: nats
+
+---
+# Source: openfaas/templates/prometheus-svc.yaml
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: openfaas
+    chart: openfaas-4.4.0
+    component: prometheus
+    heritage: Tiller
+    release: openfaas
+  name: prometheus
+  namespace: "openfaas"
+spec:
+  type: ClusterIP
+  ports:
+    - port: 9090
+      protocol: TCP
+  selector:
+    app: prometheus
+---
+# Source: openfaas/templates/alertmanager-dep.yaml
+
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: openfaas
+    chart: openfaas-4.4.0
+    component: alertmanager
+    heritage: Tiller
+    release: openfaas
+  name: alertmanager
+  namespace: "openfaas"
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: alertmanager
+      annotations:
+        sidecar.istio.io/inject: "false"
+        checksum/alertmanager-config: "92b3816feabd13d9b22c8c69e56b57dd4e45d4955ffb141db56beb2ab89105c0"
+    spec:
+      containers:
+      - name: alertmanager
+        image: prom/alertmanager:v0.16.1
+        imagePullPolicy: Always
+        command:
+          - "alertmanager"
+          - "--config.file=/alertmanager.yml"
+          - "--storage.path=/alertmanager"
+        livenessProbe:
+          httpGet:
+            path: /-/ready
+            port: 9093
+          timeoutSeconds: 30
+        readinessProbe:
+          httpGet:
+            path: /-/ready
+            port: 9093
+          timeoutSeconds: 30
+        ports:
+        - containerPort: 9093
+          protocol: TCP
+        resources:
+            limits:
+              memory: 50Mi
+            requests:
+              memory: 25Mi
+            
+        volumeMounts:
+        - mountPath: /alertmanager.yml
+          name: alertmanager-config
+          subPath: alertmanager.yml
+        - name: auth
+          readOnly: true
+          mountPath: "/var/secrets"
+      volumes:
+        - name: alertmanager-config
+          configMap:
+            name: alertmanager-config
+            items:
+              - key: alertmanager.yml
+                path: alertmanager.yml
+                mode: 0644
+        - name: auth
+          secret:
+            secretName: basic-auth
+
+---
+# Source: openfaas/templates/basic-auth-plugin-dep.yaml
+
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: openfaas
+    chart: openfaas-4.4.0
+    component: basic-auth-plugin
+    heritage: Tiller
+    release: openfaas
+  name: basic-auth-plugin
+  namespace: "openfaas"
+spec:
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        prometheus.io.scrape: "false"
+      labels:
+        app: basic-auth-plugin
+    spec:
+      volumes:
+      - name: auth
+        secret:
+          secretName: basic-auth
+      containers:
+      - name:  basic-auth-plugin
+        resources:
+            requests:
+              cpu: 20m
+              memory: 50Mi
+            
+        image: openfaas/basic-auth-plugin:0.1.1
+        imagePullPolicy: Always
+        securityContext:
+          readOnlyRootFilesystem: true
+          runAsUser: 10001
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 8080
+          timeoutSeconds: 5
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 8080
+          timeoutSeconds: 5
+        env:
+        - name: secret_mount_path
+          value: "/var/secrets"
+        - name: basic_auth
+          value: "true"
+        volumeMounts:
+        - name: auth
+          readOnly: true
+          mountPath: "/var/secrets"
+        ports:
+        - name: http
+          containerPort: 8080
+          protocol: TCP
+
+---
+# Source: openfaas/templates/faas-idler-dep.yaml
+
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: faas-idler
+  namespace: "openfaas"
+  labels:
+    app: openfaas
+    chart: openfaas-4.4.0
+    component: faas-idler
+    heritage: Tiller
+    release: openfaas
+spec:
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        prometheus.io.scrape: "false"
+      labels:
+        app: faas-idler
+    spec:
+      containers:
+        - name: faas-idler
+          resources:
+            requests:
+              memory: 64Mi
+            
+          image: openfaas/faas-idler:0.1.9
+          imagePullPolicy: Always
+          env:
+            - name: gateway_url
+              value: "http://gateway.openfaas:8080/"
+            - name: prometheus_host
+              value: "prometheus.openfaas"
+            - name: prometheus_port
+              value: "9090"
+            - name: inactivity_duration
+              value: 15m
+            - name: reconcile_interval
+              value: 1m
+          command:
+            - /home/app/faas-idler
+            - -dry-run=true
+          volumeMounts:
+            - name: auth
+              readOnly: true
+              mountPath: "/var/secrets/"
+      volumes:
+        - name: auth
+          secret:
+            secretName: basic-auth
+---
+# Source: openfaas/templates/gateway-dep.yaml
+
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: openfaas
+    chart: openfaas-4.4.0
+    component: gateway
+    heritage: Tiller
+    release: openfaas
+  name: gateway
+  namespace: "openfaas"
+spec:
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        prometheus.io.scrape: "true"
+        prometheus.io.port: "8082"
+      labels:
+        app: gateway
+    spec:
+      serviceAccountName: openfaas-controller
+      volumes:
+      - name: auth
+        secret:
+          secretName: basic-auth
+      containers:
+      - name: gateway
+        resources:
+            requests:
+              cpu: 50m
+              memory: 120Mi
+            
+        image: openfaas/gateway:0.15.0
+        imagePullPolicy: Always
+        securityContext:
+          readOnlyRootFilesystem: true
+          runAsUser: 10001
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+          timeoutSeconds: 5
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+          timeoutSeconds: 5
+        env:
+        - name: read_timeout
+          value: "65s"
+        - name: write_timeout
+          value: "65s"
+        - name: upstream_timeout
+          value: "60s"
+        - name: functions_provider_url
+          value: "http://127.0.0.1:8081/"
+        - name: direct_functions
+          value: "true"
+        - name: direct_functions_suffix
+          value: "openfaas-fn.svc.cluster.local"
+        - name: faas_nats_address
+          value: "nats.openfaas.svc.cluster.local"
+        - name: faas_nats_port
+          value: "4222"
+        - name: basic_auth
+          value: "true"
+        - name: secret_mount_path
+          value: "/var/secrets"
+        - name: auth_proxy_url
+          value: "http://basic-auth-plugin.openfaas:8080/validate"
+        - name: auth_pass_body
+          value: "false"
+        - name: scale_from_zero
+          value: "true"
+        - name: max_idle_conns
+          value: "1024"
+        - name: max_idle_conns_per_host
+          value: "1024"
+        volumeMounts:
+        - name: auth
+          readOnly: true
+          mountPath: "/var/secrets"
+        ports:
+        - name: http
+          containerPort: 8080
+          protocol: TCP
+      - name: faas-netes
+        resources:
+            requests:
+              cpu: 50m
+              memory: 120Mi
+            
+        image: openfaas/faas-netes:0.8.1
+        imagePullPolicy: 
+        securityContext:
+          readOnlyRootFilesystem: true
+          runAsUser: 10001
+        env:
+        - name: port
+          value: "8081"
+        - name: function_namespace
+          value: "openfaas-fn"
+        - name: read_timeout
+          value: "60s"
+        - name: write_timeout
+          value: "60s"
+        - name: image_pull_policy
+          value: "Always"
+        - name: http_probe
+          value: "true"
+        - name: set_nonroot_user
+          value: "false"
+        - name: readiness_probe_initial_delay_seconds
+          value: "2"
+        - name: readiness_probe_timeout_seconds
+          value: "1"
+        - name: readiness_probe_period_seconds
+          value: "2"
+        - name: liveness_probe_initial_delay_seconds
+          value: "2"
+        - name: liveness_probe_timeout_seconds
+          value: "1"
+        - name: liveness_probe_period_seconds
+          value: "2"
+        ports:
+        - containerPort: 8081
+          protocol: TCP
+
+---
+# Source: openfaas/templates/nats-dep.yaml
+
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: openfaas
+    chart: openfaas-4.4.0
+    component: nats
+    heritage: Tiller
+    release: openfaas
+  name: nats
+  namespace: "openfaas"
+spec:
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+        prometheus.io.scrape: "false"
+      labels:
+        app: nats
+    spec:
+      containers:
+      - name:  nats
+        resources:
+            requests:
+              memory: 120Mi
+            
+        image: nats-streaming:0.11.2
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 4222
+          protocol: TCP
+        command: ["/nats-streaming-server"]
+        args:
+          - --store
+          - memory
+          - --cluster_id
+          - faas-cluster
+
+---
+# Source: openfaas/templates/prometheus-dep.yaml
+
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: openfaas
+    chart: openfaas-4.4.0
+    component: prometheus
+    heritage: Tiller
+    release: openfaas
+  name: prometheus
+  namespace: "openfaas"
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: prometheus
+      annotations:
+        sidecar.istio.io/inject: "false"
+        checksum/prometheus-config: "e262edbd9780a70fc1ac2210857c48581c716bc53d1809b05893510d4a7d3c6c"
+    spec:
+      serviceAccountName: openfaas-prometheus
+      containers:
+      - name: prometheus
+        resources:
+            requests:
+              memory: 512Mi
+            
+        image: prom/prometheus:v2.7.1
+        command:
+          - "prometheus"
+          - "--config.file=/etc/prometheus/prometheus.yml"
+        imagePullPolicy: Always
+        livenessProbe:
+          httpGet:
+            path: /-/healthy
+            port: 9090
+          timeoutSeconds: 30
+        readinessProbe:
+          httpGet:
+            path: /-/healthy
+            port: 9090
+          timeoutSeconds: 30
+        ports:
+        - containerPort: 9090
+          protocol: TCP
+        volumeMounts:
+        - mountPath: /etc/prometheus/prometheus.yml
+          name: prometheus-config
+          subPath: prometheus.yml
+        - mountPath: /etc/prometheus/alert.rules.yml
+          name: prometheus-config
+          subPath: alert.rules.yml
+        - mountPath: /prometheus/data
+          name: prom-data
+      volumes:
+        - name: prometheus-config
+          configMap:
+            name: prometheus-config
+            items:
+              - key: prometheus.yml
+                path: prometheus.yml
+                mode: 0644
+              - key: alert.rules.yml
+                path: alert.rules.yml
+                mode: 0644
+        - name: prom-data
+          emptyDir: {}
+
+---
+# Source: openfaas/templates/queueworker-dep.yaml
+
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: openfaas
+    chart: openfaas-4.4.0
+    component: queue-worker
+    heritage: Tiller
+    release: openfaas
+  name: queue-worker
+  namespace: "openfaas"
+spec:
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        prometheus.io.scrape: "false"
+      labels:
+        app: queue-worker
+    spec:
+      volumes:
+      - name: auth
+        secret:
+          secretName: basic-auth
+      containers:
+      - name:  queue-worker
+        resources:
+            requests:
+              cpu: 50m
+              memory: 120Mi
+            
+        image: openfaas/queue-worker:0.7.2
+        imagePullPolicy: Always
+        env:
+        - name: faas_nats_address
+          value: "nats.openfaas.svc.cluster.local"
+        - name: faas_gateway_address
+          value: "gateway.openfaas.svc.cluster.local"
+        - name: "gateway_invoke"
+          value: "true"
+        - name: faas_function_suffix
+          value: ".openfaas-fn.svc.cluster.local"
+        - name: ack_wait    # Max duration of any async task / request
+          value: 60s
+        - name: secret_mount_path
+          value: "/var/secrets"
+        - name: basic_auth
+          value: "true"
+        volumeMounts:
+        - name: auth
+          readOnly: true
+          mountPath: "/var/secrets"
+
+---
+# Source: openfaas/templates/crd.yaml
+
+
+---
+# Source: openfaas/templates/ingress.yaml
+
+---
+# Source: openfaas/templates/operator-rbac.yaml
+


### PR DESCRIPTION
Adds OpenFaaS at chart version 4.4.0

* Corrected a typo in the CONTRIBUTING guide
* Added OpenFaaS namespaces as part of install (there are 2x needed)
* Corrected error for checking for rollout-status of deployment, it's not "openfaas", but "gateway" that needs to be checked for
* Updated the instructions for OpenFaaS to include a `$HELM_CHART_REPO`, given that a separate repo is maintained for the project.
* Tested with DOKS cluster in Amsterdam.

Signed-off-by: Alex Ellis <alexellis2@gmail.com>

Fixes: https://github.com/openfaas/faas/issues/1261
Fixes: https://github.com/digitalocean/marketplace-kubernetes/issues/16