### PR TITLE
metrics-server: :fire: --kubelet-insecure-tls

### DIFF
--- a/stacks/metrics-server/patch/patch.yaml
+++ b/stacks/metrics-server/patch/patch.yaml
@@ -10,4 +10,3 @@ spec:
         command:
           - /metrics-server
           - --kubelet-preferred-address-types=InternalIP
-          - --kubelet-insecure-tls


### PR DESCRIPTION
The [latest DOKS versions](https://www.digitalocean.com/docs/kubernetes/changelog/#1.15.x) enable kubelets to serve TLS from node IPs, which allows us to stop using `--kubelet-insecure-tls` on metrics-server.