### PR TITLE
Fix Moon 1.16 incompatibilities

### DIFF
--- a/stacks/moon/yaml/moon.yaml
+++ b/stacks/moon/yaml/moon.yaml
@@ -63,13 +63,16 @@ spec:
 #              serviceName: moon
 #              servicePort: 8080
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: moon
   namespace: moon
 spec:
   replicas: 2
+  selector:
+    matchLabels:
+      app: moon
   template:
     metadata:
       labels:


### PR DESCRIPTION
The `apps/v1beta1` API was deprecated in Kubernetes 1.16 ([more info](https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/)). This patch makes this app 1.16 compatible.

cc @vania-pooh