### PR TITLE
Fix Netdata 1.16 API bug

### DIFF
--- a/stacks/netdata/yaml/netdata.yaml
+++ b/stacks/netdata/yaml/netdata.yaml
@@ -302,7 +302,7 @@ spec:
 
 ---
 # Source: netdata/templates/statefulset.yaml
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: netdata-master


### PR DESCRIPTION
The `apps/v1beta2` API was deprecated in Kubernetes 1.16 ([more info](https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/)). This patch makes this app 1.16 compatible.

cc @cakrit