### PR TITLE
Fix 1Password SCIM bridge 1.16 API bug

### DIFF
--- a/stacks/op-scim-bridge/yaml/op-scim-bridge.yaml
+++ b/stacks/op-scim-bridge/yaml/op-scim-bridge.yaml
@@ -1,6 +1,6 @@
 ---
 # Source: op-scim/templates/op-scim.yaml
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: op-scim-bridge
@@ -80,7 +80,7 @@ spec:
   storageClassName: do-block-storage
 ---
 # Source: op-scim/templates/redis.yaml
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: redis


### PR DESCRIPTION
The `apps/v1beta2` API was deprecated in Kubernetes 1.16 ([more info](https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/)). This patch makes this app 1.16 compatible.

cc @cohix - whenever you get a chance, please submit an update
