### PR TITLE
Add kube-state-metrics

### DIFF
--- a/src/kube-state-metrics/1.8/kube-state-metrics-cluster-role-binding.yaml
+++ b/src/kube-state-metrics/1.8/kube-state-metrics-cluster-role-binding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+# kubernetes versions before 1.8.0 should use rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: kube-state-metrics
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kube-state-metrics
+subjects:
+- kind: ServiceAccount
+  name: kube-state-metrics
+  namespace: kube-system

--- a/src/kube-state-metrics/1.8/kube-state-metrics-cluster-role.yaml
+++ b/src/kube-state-metrics/1.8/kube-state-metrics-cluster-role.yaml
@@ -1,0 +1,60 @@
+apiVersion: rbac.authorization.k8s.io/v1
+# kubernetes versions before 1.8.0 should use rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: kube-state-metrics
+rules:
+- apiGroups: [""]
+  resources:
+  - configmaps
+  - secrets
+  - nodes
+  - pods
+  - services
+  - resourcequotas
+  - replicationcontrollers
+  - limitranges
+  - persistentvolumeclaims
+  - persistentvolumes
+  - namespaces
+  - endpoints
+  verbs: ["list", "watch"]
+- apiGroups: ["extensions"]
+  resources:
+  - daemonsets
+  - deployments
+  - replicasets
+  - ingresses
+  verbs: ["list", "watch"]
+- apiGroups: ["apps"]
+  resources:
+  - daemonsets
+  - deployments
+  - replicasets
+  - statefulsets
+  verbs: ["list", "watch"]
+- apiGroups: ["batch"]
+  resources:
+  - cronjobs
+  - jobs
+  verbs: ["list", "watch"]
+- apiGroups: ["autoscaling"]
+  resources:
+  - horizontalpodautoscalers
+  verbs: ["list", "watch"]
+- apiGroups: ["policy"]
+  resources:
+  - poddisruptionbudgets
+  verbs: ["list", "watch"]
+- apiGroups: ["certificates.k8s.io"]
+  resources:
+  - certificatesigningrequests
+  verbs: ["list", "watch"]
+- apiGroups: ["storage.k8s.io"]
+  resources:
+  - storageclasses
+  verbs: ["list", "watch"]
+- apiGroups: ["autoscaling.k8s.io"]
+  resources:
+  - verticalpodautoscalers
+  verbs: ["list", "watch"]

--- a/src/kube-state-metrics/1.8/kube-state-metrics-deployment.yaml
+++ b/src/kube-state-metrics/1.8/kube-state-metrics-deployment.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    k8s-app: kube-state-metrics
+  name: kube-state-metrics
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      k8s-app: kube-state-metrics
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        k8s-app: kube-state-metrics
+    spec:
+      serviceAccountName: kube-state-metrics
+      containers:
+      - name: kube-state-metrics
+        image: quay.io/coreos/kube-state-metrics:v1.8.0
+        ports:
+        - name: http-metrics
+          containerPort: 8080
+        - name: telemetry
+          containerPort: 8081
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+          initialDelaySeconds: 5
+          timeoutSeconds: 5
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 8080
+          initialDelaySeconds: 5
+          timeoutSeconds: 5

--- a/src/kube-state-metrics/1.8/kube-state-metrics-service-account.yaml
+++ b/src/kube-state-metrics/1.8/kube-state-metrics-service-account.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-state-metrics
+  namespace: kube-system

--- a/src/kube-state-metrics/1.8/kube-state-metrics-service.yaml
+++ b/src/kube-state-metrics/1.8/kube-state-metrics-service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: kube-state-metrics
+  namespace: kube-system
+  labels:
+    k8s-app: kube-state-metrics
+  annotations:
+    prometheus.io/scrape: 'true'
+spec:
+  ports:
+  - name: http-metrics
+    port: 8080
+    targetPort: http-metrics
+    protocol: TCP
+  - name: telemetry
+    port: 8081
+    targetPort: telemetry
+    protocol: TCP
+  selector:
+    k8s-app: kube-state-metrics

--- a/src/kube-state-metrics/1.8/kustomization.yaml
+++ b/src/kube-state-metrics/1.8/kustomization.yaml
@@ -1,0 +1,11 @@
+commonLabels:
+  app.kubernetes.io/name: kube-state-metrics
+
+namespace: kube-system
+
+resources:
+- kube-state-metrics-cluster-role-binding.yaml
+- kube-state-metrics-cluster-role.yaml
+- kube-state-metrics-deployment.yaml
+- kube-state-metrics-service-account.yaml
+- kube-state-metrics-service.yaml

--- a/stacks/kube-state-metrics/README.md
+++ b/stacks/kube-state-metrics/README.md
@@ -1,0 +1,3 @@
+# kube-state-metrics
+
+https://github.com/kubernetes/kube-state-metrics

--- a/stacks/kube-state-metrics/deploy-local.sh
+++ b/stacks/kube-state-metrics/deploy-local.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+set -e
+
+ROOT_DIR=$(git rev-parse --show-toplevel)
+
+# set kubectl namespace
+kubectl config set-context --current --namespace=kube-system
+
+# deploy kube-state-metrics
+kubectl apply -f "$ROOT_DIR"/stacks/kube-state-metrics/yaml/kube-state-metrics.yaml
+
+# ensure services are running
+kubectl rollout status -w deployment/kube-state-metrics

--- a/stacks/kube-state-metrics/deploy.sh
+++ b/stacks/kube-state-metrics/deploy.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+set -e
+
+# set kubectl namespace
+kubectl config set-context --current --namespace=kube-system
+
+# deploy kube-state-metrics
+kubectl apply -f https://raw.githubusercontent.com/digitalocean/marketplace-kubernetes/master/stacks/kube-state-metrics/yaml/kube-state-metrics.yaml
+
+# ensure services are running
+kubectl rollout status -w deployment/kube-state-metrics

--- a/stacks/kube-state-metrics/render.sh
+++ b/stacks/kube-state-metrics/render.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+set -e
+
+BUILD_DIR=$(mktemp -d)
+ROOT_DIR=$(git rev-parse --show-toplevel)
+
+KUBE_STATE_METRICS_VERSION="1.8"
+
+# Create YAML directory
+rm -rf "$ROOT_DIR"/stacks/kube-state-metrics/yaml
+mkdir -p "$ROOT_DIR"/stacks/kube-state-metrics/yaml
+
+# render kube-state-metrics
+cp -r "$ROOT_DIR"/src/kube-state-metrics/"$KUBE_STATE_METRICS_VERSION"/ "$BUILD_DIR"
+kubectl kustomize "$BUILD_DIR" > "$ROOT_DIR"/stacks/kube-state-metrics/yaml/kube-state-metrics.yaml

--- a/stacks/kube-state-metrics/yaml/kube-state-metrics.yaml
+++ b/stacks/kube-state-metrics/yaml/kube-state-metrics.yaml
@@ -1,0 +1,177 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/name: kube-state-metrics
+  name: kube-state-metrics
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: kube-state-metrics
+  name: kube-state-metrics
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - secrets
+  - nodes
+  - pods
+  - services
+  - resourcequotas
+  - replicationcontrollers
+  - limitranges
+  - persistentvolumeclaims
+  - persistentvolumes
+  - namespaces
+  - endpoints
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - extensions
+  resources:
+  - daemonsets
+  - deployments
+  - replicasets
+  - ingresses
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - daemonsets
+  - deployments
+  - replicasets
+  - statefulsets
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - cronjobs
+  - jobs
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - certificates.k8s.io
+  resources:
+  - certificatesigningrequests
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - autoscaling.k8s.io
+  resources:
+  - verticalpodautoscalers
+  verbs:
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/name: kube-state-metrics
+  name: kube-state-metrics
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kube-state-metrics
+subjects:
+- kind: ServiceAccount
+  name: kube-state-metrics
+  namespace: kube-system
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/scrape: "true"
+  labels:
+    app.kubernetes.io/name: kube-state-metrics
+    k8s-app: kube-state-metrics
+  name: kube-state-metrics
+  namespace: kube-system
+spec:
+  ports:
+  - name: http-metrics
+    port: 8080
+    protocol: TCP
+    targetPort: http-metrics
+  - name: telemetry
+    port: 8081
+    protocol: TCP
+    targetPort: telemetry
+  selector:
+    app.kubernetes.io/name: kube-state-metrics
+    k8s-app: kube-state-metrics
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/name: kube-state-metrics
+    k8s-app: kube-state-metrics
+  name: kube-state-metrics
+  namespace: kube-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kube-state-metrics
+      k8s-app: kube-state-metrics
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: kube-state-metrics
+        k8s-app: kube-state-metrics
+    spec:
+      containers:
+      - image: quay.io/coreos/kube-state-metrics:v1.8.0
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+          initialDelaySeconds: 5
+          timeoutSeconds: 5
+        name: kube-state-metrics
+        ports:
+        - containerPort: 8080
+          name: http-metrics
+        - containerPort: 8081
+          name: telemetry
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 8080
+          initialDelaySeconds: 5
+          timeoutSeconds: 5
+      serviceAccountName: kube-state-metrics


### PR DESCRIPTION
[kube-state-metrics](https://github.com/kubernetes/kube-state-metrics) is needed for [advanced metrics](https://www.digitalocean.com/docs/kubernetes/how-to/monitor-advanced/) on DOKS clusters, it would be great if it could be added through the MP workflow.