### PR TITLE
Add Action to test 1-click on stacks PRs

### DIFF
--- a/.github/workflows/k8s-pr-test.yml
+++ b/.github/workflows/k8s-pr-test.yml
@@ -41,7 +41,7 @@ jobs:
       # jq and cut used to save just the Addon Slug string.
     - name: Identify and set the Addon Slug as an environmental variable
       id: vars
-      run: echo ::set-env name=ADDON_SLUG::"`curl -sS https://api.github.com/repos/arosales/marketplace-kubernetes/pulls/${{ github.event.pull_request.number }}/files |  jq  -r '.[] | .filename' | cut -d/ -f2`"
+      run: echo ::set-env name=ADDON_SLUG::"`curl -sS https://api.github.com/repos/digitalocean/marketplace-kubernetes/pulls/${{ github.event.pull_request.number }}/files |  jq  -r '.[] | .filename' | cut -d/ -f2`"
 
     - name: Checkout marketplace-kubernetes repo
       uses: actions/checkout@master
@@ -64,7 +64,6 @@ jobs:
         args: kubernetes cluster kubeconfig show test-gh-mp-k8s-${{ github.event.pull_request.number }} > $GITHUB_WORKSPACE/.kubeconfig
 
       # GitHub actions was unhappy with read and execute (555) permissions.
-      #         sudo chmod 777 stacks/${{ env.ADDON_SLUG }}/deploy.sh
     - name: Deploy proposed new or updated deploy.sh to test K8s cluster
       run: |
         sudo chmod 777 $GITHUB_WORKSPACE/.kubeconfig

--- a/.github/workflows/k8s-pr-test.yml
+++ b/.github/workflows/k8s-pr-test.yml
@@ -1,0 +1,78 @@
+# About:
+# This action runs when a non-doc Pull Request has been made to the
+# stack directory or any of it subdirectories. This action will test
+# in the same manner the Addon Service applies K8s 1-clicks,
+# using the deploy.sh script and relaying on rollout status to
+# confirm a successfull deploy. This action does NOT test
+# functionality in the k8 1-click app.
+
+# Note:
+# A DigitalOcean token needs to be saved in the repo 
+# Settings --> Secrets with the name, "DIGITALOCEAN_ACCESS_TOKEN"
+# DigitalOcean Tokens doc: 
+#   https://www.digitalocean.com/docs/apis-clis/api/create-personal-access-token/
+# 
+# A 2vCPU 2GB Memory 3 Node cluster in SFO2 is spun up to test. The cluster
+# name includes the Pull Request number. 
+# Once the rollout finishes the cluster is deleted.
+# 
+# This action also makes use of the DOCTL Action:
+#   https://github.com/digitalocean/action-doctl
+
+name: DigitalOcean Kubernetes Test
+on:
+  pull_request:
+    # Do not test if the only update was a doc update,
+    # ie new or edit of an existing markdown file.
+    # Only test if a change was made to the stacks subdirectories.
+    # This assumes any change to source would have to be rendered.
+    paths:
+    - 'stacks/**'    
+    - '!stacks/**/*.md'
+
+jobs:
+
+  build:
+    name: Identify Addon Slug and K8s Rollout Test
+    runs-on: ubuntu-latest
+    steps:
+
+      # Leverage the GitHub API was easier than diffing aginast how actions checkouts out the PR branch.
+      # jq and cut used to save just the Addon Slug string.
+    - name: Identify and set the Addon Slug as an environmental variable
+      id: vars
+      run: echo ::set-env name=ADDON_SLUG::"`curl -sS https://api.github.com/repos/arosales/marketplace-kubernetes/pulls/${{ github.event.pull_request.number }}/files |  jq  -r '.[] | .filename' | cut -d/ -f2`"
+
+    - name: Checkout marketplace-kubernetes repo
+      uses: actions/checkout@master
+
+    - name: Log the Addon Slug to test
+      run: echo ${{ env.ADDON_SLUG }}
+
+    - name: Create DigitalOcean Kubernetes test cluster (3 node 2vCPU 2GB)
+      uses: digitalocean/action-doctl@master
+      env:
+        DIGITALOCEAN_ACCESS_TOKEN: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+      with:
+        args: kubernetes cluster create --region sfo2 --tag gh-test-pr --size s-2vcpu-2gb --count 3 test-gh-mp-k8s-${{ github.event.pull_request.number }}
+
+    - name: Save kubeconfig to GitHub Workspace
+      uses: digitalocean/action-doctl@master
+      env:
+        DIGITALOCEAN_ACCESS_TOKEN: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+      with:  
+        args: kubernetes cluster kubeconfig show test-gh-mp-k8s-${{ github.event.pull_request.number }} > $GITHUB_WORKSPACE/.kubeconfig
+
+      # GitHub actions was unhappy with read and execute (555) permissions.
+      #         sudo chmod 777 stacks/${{ env.ADDON_SLUG }}/deploy.sh
+    - name: Deploy proposed new or updated deploy.sh to test K8s cluster
+      run: |
+        sudo chmod 777 $GITHUB_WORKSPACE/.kubeconfig
+        export KUBECONFIG=$GITHUB_WORKSPACE/.kubeconfig
+        sh stacks/${{ env.ADDON_SLUG }}/deploy.sh
+    - name: Delete DigitalOcean Kubernetes test cluster
+      uses: digitalocean/action-doctl@master
+      env:
+        DIGITALOCEAN_ACCESS_TOKEN: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+      with:
+        args: kubernetes cluster delete --force test-gh-mp-k8s-${{ github.event.pull_request.number }}


### PR DESCRIPTION
## BACKGROUND
### Problem

We need an automatic way to do Kubernetes rollout testing of non-doc Pull Requests made to the stacks directory. This should give feedback to contributors if their DigitalOcean Kubernetes 1-click will be deployed as expected before requesting a review from a repo Code Owner. 
The testing should use the same mechanisms as production 1-clicks to give accurate feedback. Kubernetes testing should block any subsequent reviews on the PR, meaning all tests should first pass before a human review is done. The testing itself should give verbose logging to properly inform reviewers and submitters. 
Code reviewers should be able to lean on this auto-testing to ensure the PR successfully does a rollout deployment. Additional testing should be later added to run integration tests to ensure the application is functioning as expected. 


## Changes
### Proposed Solution

This PR makes use of GitHub Actions to detect when a non-doc update (doc ==*.md file)  has been made to to the stacks directory or any of its subdirectories and executes the modified/new 1-click deploy.sh script. It does not test on changes to any other directories because:
- Any changes requiring a test on a Kubernetes cluster will need to have the render script ran and stacks directory updated.
- deploy.sh is the mechanism the DigitalOcean Addon Service uses to apply Kubernetes 1-clicks to target clusters.
This solution spins up a 2vCPU 2GB Memory 3 Node cluster in SFO2. The cluster name includes the Pull Request number.  Once the rollout finishes the cluster is deleted. A DigitalOcean token needs to be saved in the repo Settings --> Secrets with the name,"DIGITALOCEAN_ACCESS_TOKEN"
This solution also assumes only one 1-click is modified per PR.

## Testing

I have sucessfully tested:
- When and update is src directory no Kubernetes testing is invoked: https://github.com/arosales/marketplace-kubernetes/pull/49
- When an update is made to a Markdown file no Kubernetes testing is invoked: https://github.com/arosales/marketplace-kubernetes/pull/48
- When an udpate is made to the stacks director Kubernetes testing is invoked: https://github.com/arosales/marketplace-kubernetes/pull/47

## Checklist
- [x] review the [contributing doc](https://github.com/digitalocean/marketplace-kubernetes/blob/master/CONTRIBUTING.md) with steps for both adding or updating your application (if applicable)

Reviewer: @marketplace-eng
