### PR TITLE
Port workflow to action-doctl v2.

### DIFF
--- a/.github/workflows/k8s-pr-test.yml
+++ b/.github/workflows/k8s-pr-test.yml
@@ -49,29 +49,19 @@ jobs:
     - name: Log the Addon Slug to test
       run: echo ${{ env.ADDON_SLUG }}
 
-    - name: Create DigitalOcean Kubernetes test cluster (3 node 2vCPU 2GB)
-      uses: digitalocean/action-doctl@master
-      env:
-        DIGITALOCEAN_ACCESS_TOKEN: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+    - name: Install doctl
+      uses: digitalocean/action-doctl@v2
       with:
-        args: kubernetes cluster create --region sfo2 --tag gh-test-pr --size s-2vcpu-2gb --count 3 test-gh-mp-k8s-${{ github.event.pull_request.number }}
+        token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+
+    - name: Create DigitalOcean Kubernetes test cluster (3 node 2vCPU 2GB)
+      run: doctl kubernetes cluster create --region sfo2 --tag gh-test-pr --size s-2vcpu-2gb --count 3 test-gh-mp-k8s-${{ github.event.pull_request.number }}
 
     - name: Save kubeconfig to GitHub Workspace
-      uses: digitalocean/action-doctl@master
-      env:
-        DIGITALOCEAN_ACCESS_TOKEN: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
-      with:  
-        args: kubernetes cluster kubeconfig show test-gh-mp-k8s-${{ github.event.pull_request.number }} > $GITHUB_WORKSPACE/.kubeconfig
+      run: doctl kubernetes cluster kubeconfig save test-gh-mp-k8s-${{ github.event.pull_request.number }}
 
-      # GitHub actions was unhappy with read and execute (555) permissions.
     - name: Deploy proposed new or updated deploy-local.sh to test K8s cluster
-      run: |
-        sudo chmod 777 $GITHUB_WORKSPACE/.kubeconfig
-        export KUBECONFIG=$GITHUB_WORKSPACE/.kubeconfig
-        sh stacks/${{ env.ADDON_SLUG }}/deploy-local.sh
+      run: sh stacks/${{ env.ADDON_SLUG }}/deploy-local.sh
+
     - name: Delete DigitalOcean Kubernetes test cluster
-      uses: digitalocean/action-doctl@master
-      env:
-        DIGITALOCEAN_ACCESS_TOKEN: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
-      with:
-        args: kubernetes cluster delete --force test-gh-mp-k8s-${{ github.event.pull_request.number }}
+      run: doctl kubernetes cluster delete --force test-gh-mp-k8s-${{ github.event.pull_request.number }}


### PR DESCRIPTION
## BACKGROUND

Recently, the doctl GitHub Action made a v2 release making a number of changes to how it functions as described here: https://github.com/digitalocean/action-doctl/issues/27

## Changes

This PR ports the existing workflow to use v2 of the doctl GitHub Action.

This should allow for just using `doctl kubernetes cluster kubeconfig save` rather than redirecting output to `$GITHUB_WORKSPACE/.kubeconfig`

Since this only runs when a file under `stacks/` is changed, I've done a successful test run of a change to a stack against my fork:

https://github.com/andrewsomething/marketplace-kubernetes/pull/3
https://github.com/andrewsomething/marketplace-kubernetes/runs/616611966?check_suite_focus=true

## Checklist
- [x] review the [contributing doc](https://github.com/digitalocean/marketplace-kubernetes/blob/master/CONTRIBUTING.md) with steps for both adding or updating your application (if applicable)
------------------------------------------------------------------------

Reviewer: @marketplace-eng
