### PR TITLE
Added persistance to monitoring stack grafana

### DIFF
--- a/stacks/kube-prometheus-stack/values.yml
+++ b/stacks/kube-prometheus-stack/values.yml
@@ -1,1 +1,6 @@
 # prometheus-community/kube-prometheus-stack
+
+grafana:
+  persistence:
+    enabled: true
+    size: 10Gi


### PR DESCRIPTION
This change adds a 10 GB pvc to the monitoring stack deployment, allowing for the persistence of customized grafana dashboards. This addresses https://github.com/digitalocean/marketplace-kubernetes/issues/175 and https://github.com/digitalocean/marketplace-kubernetes/issues/158.