### PR TITLE
Version bump the 1Password SCIM bridge to 1.6.2

### DIFF
--- a/stacks/op-scim-bridge/deploy.sh
+++ b/stacks/op-scim-bridge/deploy.sh
@@ -7,7 +7,7 @@ helm repo update > /dev/null
 
 STACK="op-scim-bridge"
 CHART="op-scim-bridge/op-scim"
-CHART_VERSION="1.6.1"
+CHART_VERSION="1.6.2"
 NAMESPACE="op-scim-bridge"
 
 helm upgrade "$STACK" "$CHART" \


### PR DESCRIPTION
## BACKGROUND
* We released a new version of the 1Password SCIM bridge. [Changelog](https://app-updates.agilebits.com/product_history/SCIM#v106021)

-----------------------------------------------------------------------

## Changes
* This PR updates our DO Marketplace Application to v1.6.2 of [our Helm Chart](https://github.com/1Password/op-scim-helm). 

-----------------------------------------------------------------------

## Checklist
- [x] review the [contributing doc](https://github.com/digitalocean/marketplace-kubernetes/blob/master/CONTRIBUTING.md) with steps for both adding or updating your application (if applicable)
------------------------------------------------------------------------

Reviewer: @marketplace-eng
