### PR TITLE
Update 1Password SCIM bridge version to 2.0.0

### DIFF
--- a/stacks/op-scim-bridge/deploy.sh
+++ b/stacks/op-scim-bridge/deploy.sh
@@ -7,7 +7,7 @@ helm repo update > /dev/null
 
 STACK="op-scim-bridge"
 CHART="op-scim-bridge/op-scim"
-CHART_VERSION="1.6.2"
+CHART_VERSION="2.0.0"
 NAMESPACE="op-scim-bridge"
 
 helm upgrade "$STACK" "$CHART" \


### PR DESCRIPTION
## BACKGROUND
* 1Password SCIM bridge v2.0.0 was released and we are updating our downstream applications.

-----------------------------------------------------------------------

## Changes
* Update helm chart v1.6.2 to v2.0.0 

-----------------------------------------------------------------------

## Checklist
- [x] review the [contributing doc](https://github.com/digitalocean/marketplace-kubernetes/blob/master/CONTRIBUTING.md) with steps for both adding or updating your application (if applicable)
------------------------------------------------------------------------

Reviewer: @marketplace-eng
