### PR TITLE
SCIM bridge version 2.0.1

### DIFF
--- a/stacks/op-scim-bridge/deploy.sh
+++ b/stacks/op-scim-bridge/deploy.sh
@@ -7,7 +7,7 @@ helm repo update > /dev/null
 
 STACK="op-scim-bridge"
 CHART="op-scim-bridge/op-scim"
-CHART_VERSION="2.0.0"
+CHART_VERSION="2.0.1"
 NAMESPACE="op-scim-bridge"
 
 helm upgrade "$STACK" "$CHART" \


### PR DESCRIPTION
## BACKGROUND
* The 1Password SCIM bridge has released a patch version `2.0.1`.

-----------------------------------------------------------------------

## Changes
* Bumped the SCIM bridge `op-scim-bridge` to version `2.0.1`

-----------------------------------------------------------------------

## Checklist
- [X] review the [contributing doc](https://github.com/digitalocean/marketplace-kubernetes/blob/master/CONTRIBUTING.md) with steps for both adding or updating your application (if applicable)
------------------------------------------------------------------------

Reviewer: @marketplace-eng
