### PR TITLE
Add Redpanda operator and cluster to one click application

### DIFF
--- a/stacks/Redpanda/deploy.sh
+++ b/stacks/Redpanda/deploy.sh
@@ -1,0 +1,68 @@
+#!/bin/sh
+
+set -e
+
+################################################################################
+# repo
+################################################################################
+helm repo add vectorized https://charts.vectorized.io/
+helm repo add jetstack https://charts.jetstack.io
+helm repo add prom https://prometheus-community.github.io/helm-charts
+helm repo update > /dev/null
+
+################################################################################
+# chart
+################################################################################
+STACK="redpanda"
+CHART="vectorized/redpanda-operator"
+CHART_VERSION="v21.5.1"
+NAMESPACE="redpanda-system"
+
+if [ -z "${MP_KUBERNETES}" ]; then
+  # use local version of values.yml
+  ROOT_DIR=$(git rev-parse --show-toplevel)
+  values="$ROOT_DIR/stacks/Redpanda/values.yml"
+else
+  # use github hosted master version of values.yml
+  values="https://raw.githubusercontent.com/digitalocean/marketplace-kubernetes/master/stacks/Redpanda/values.yml"
+fi
+
+helm upgrade \
+  cert-manager jetstack/cert-manager \
+  --atomic \
+  --create-namespace \
+  --install \
+  --namespace cert-manager \
+  --version v1.2.0 \
+  --set installCRDs=true
+
+helm upgrade \
+  prometheus-operator prom/kube-prometheus-stack \
+  --atomic \
+  --create-namespace \
+  --install \
+  --namespace monitoring \
+  --version 15.4.4
+
+kubectl apply -k "https://github.com/vectorizedio/redpanda/src/go/k8s/config/crd?ref=$CHART_VERSION"
+
+helm upgrade "$STACK" "$CHART" \
+  --atomic \
+  --create-namespace \
+  --install \
+  --namespace "$NAMESPACE" \
+  --values "$values" \
+  --version "$CHART_VERSION"
+
+MAX=50
+CURRENT=0
+
+until $(kubectl apply -f "https://raw.githubusercontent.com/vectorizedio/redpanda/v21.5.1/src/go/k8s/config/samples/external_connectivity.yaml" >/dev/null 2>&1); do
+  CURRENT=$((CURRENT + 1))
+  sleep 1
+
+  if [ "$CURRENT" -gt "$MAX" ]; then
+    echo "FAILED: Webhook not ready, giving up."
+    exit 1
+  fi
+done

--- a/stacks/Redpanda/uninstall.sh
+++ b/stacks/Redpanda/uninstall.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+set -e
+set -x
+################################################################################
+# chart
+################################################################################
+STACK="redpanda"
+NAMESPACE="redpanda-system"
+CHART_VERSION="v21.5.1"
+
+kubectl delete -f "https://raw.githubusercontent.com/vectorizedio/redpanda/v21.5.1/src/go/k8s/config/samples/external_connectivity.yaml"
+
+helm uninstall "$STACK" \
+  --namespace "$NAMESPACE"
+
+kubectl delete -k "https://github.com/vectorizedio/redpanda/src/go/k8s/config/crd?ref=$CHART_VERSION"
+
+helm uninstall prometheus-operator\
+  --namespace monitoring
+
+helm uninstall cert-manager \
+  --namespace cert-manager

--- a/stacks/Redpanda/upgrade.sh
+++ b/stacks/Redpanda/upgrade.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+
+set -e
+
+################################################################################
+# repo
+################################################################################
+helm repo add vectorized https://charts.vectorized.io/
+helm repo add jetstack https://charts.jetstack.io
+helm repo add prom https://prometheus-community.github.io/helm-charts
+helm repo update > /dev/null
+
+################################################################################
+# chart
+################################################################################
+STACK="redpanda"
+CHART="vectorized/redpanda-operator"
+CHART_VERSION="v21.5.1"
+NAMESPACE="redpanda-system"
+
+if [ -z "${MP_KUBERNETES}" ]; then
+    # use local version of values.yml
+    ROOT_DIR=$(git rev-parse --show-toplevel)
+    values="$ROOT_DIR/stacks/Redpanda/values.yml"
+else
+    # use github hosted master version of values.yml
+    values="https://raw.githubusercontent.com/digitalocean/marketplace-kubernetes/master/stacks/Redpanda/values.yml"
+fi
+
+helm upgrade \
+  cert-manager jetstack/cert-manager \
+  --namespace cert-manager \
+  --set installCRDs=true
+
+helm upgrade \
+  prometheus-operator prom/kube-prometheus-stack \
+  --namespace monitoring \
+  --version 15.4.4
+
+kubectl apply -k "https://github.com/vectorizedio/redpanda/src/go/k8s/config/crd?ref=$CHART_VERSION"
+
+helm upgrade "$STACK" "$CHART" \
+--namespace "$NAMESPACE" \
+--values "$values" \
+
+until $(kubectl apply -f "https://raw.githubusercontent.com/vectorizedio/redpanda/v21.5.1/src/go/k8s/config/samples/external_connectivity.yaml" >/dev/null 2>&1); do
+  CURRENT=$((CURRENT + 1))
+  sleep 1
+
+  if [ "$CURRENT" -gt "$MAX" ]; then
+    echo "FAILED: Webhook not ready, giving up."
+    exit 1
+  fi
+done

--- a/stacks/Redpanda/values.yml
+++ b/stacks/Redpanda/values.yml
@@ -1,0 +1,1 @@
+# redpanda-operator


### PR DESCRIPTION
## BACKGROUND

To enable users in Digital Ocean that would like to use Redpanda streaming platform that is Kafka® compatible.

https://github.com/vectorizedio/redpanda/

> Redpanda is a streaming platform for mission critical workloads. Kafka® compatible, No Zookeeper®, no JVM, and no code changes required. Use all your favorite open source tooling - 10x faster.

-----------------------------------------------------------------------

## Changes
* Add Redpanda stack using [generate-stack.sh](https://github.com/digitalocean/marketplace-kubernetes/blob/master/utils/generate-stack.sh).

-----------------------------------------------------------------------

## Checklist
- [X] review the [contributing doc](https://github.com/digitalocean/marketplace-kubernetes/blob/master/CONTRIBUTING.md) with steps for both adding or updating your application (if applicable)
------------------------------------------------------------------------

Reviewer: @marketplace-eng
