### PR TITLE
Bump Redpanda version

### DIFF
--- a/stacks/redpanda/deploy.sh
+++ b/stacks/redpanda/deploy.sh
@@ -21,7 +21,7 @@ NAMESPACE="redpanda-system"
 if [ -z "${MP_KUBERNETES}" ]; then
   # use local version of values.yml
   ROOT_DIR=$(git rev-parse --show-toplevel)
-  values="$ROOT_DIR/stacks/Redpanda/values.yml"
+  values="$ROOT_DIR/stacks/redpanda/values.yml"
 else
   # use github hosted master version of values.yml
   values="https://raw.githubusercontent.com/digitalocean/marketplace-kubernetes/master/stacks/redpanda/values.yml"

--- a/stacks/redpanda/deploy.sh
+++ b/stacks/redpanda/deploy.sh
@@ -15,7 +15,7 @@ helm repo update > /dev/null
 ################################################################################
 STACK="redpanda"
 CHART="vectorized/redpanda-operator"
-CHART_VERSION="v21.5.1"
+CHART_VERSION="v21.5.5"
 NAMESPACE="redpanda-system"
 
 if [ -z "${MP_KUBERNETES}" ]; then

--- a/stacks/redpanda/deploy.sh
+++ b/stacks/redpanda/deploy.sh
@@ -7,7 +7,6 @@ set -e
 ################################################################################
 helm repo add vectorized https://charts.vectorized.io/
 helm repo add jetstack https://charts.jetstack.io
-helm repo add prom https://prometheus-community.github.io/helm-charts
 helm repo update > /dev/null
 
 ################################################################################
@@ -35,14 +34,6 @@ helm upgrade \
   --namespace cert-manager \
   --version v1.2.0 \
   --set installCRDs=true
-
-helm upgrade \
-  prometheus-operator prom/kube-prometheus-stack \
-  --atomic \
-  --create-namespace \
-  --install \
-  --namespace monitoring \
-  --version 15.4.4
 
 kubectl apply -k "https://github.com/vectorizedio/redpanda/src/go/k8s/config/crd?ref=$CHART_VERSION"
 

--- a/stacks/redpanda/deploy.sh
+++ b/stacks/redpanda/deploy.sh
@@ -57,7 +57,7 @@ helm upgrade "$STACK" "$CHART" \
 MAX=50
 CURRENT=0
 
-until $(kubectl apply -f "https://raw.githubusercontent.com/vectorizedio/redpanda/v21.5.1/src/go/k8s/config/samples/external_connectivity.yaml" >/dev/null 2>&1); do
+until $(kubectl apply -f "https://raw.githubusercontent.com/vectorizedio/redpanda/$CHART_VERSION/src/go/k8s/config/samples/external_connectivity.yaml" >/dev/null 2>&1); do
   CURRENT=$((CURRENT + 1))
   sleep 1
 


### PR DESCRIPTION
## BACKGROUND
* Redpanda stack failed to install in 3 node Kubernetes cluster on DigitalOcean. To slim amount of services installed by the stack this PR removes obsolete prometheus stack.

-----------------------------------------------------------------------

## Changes
* Remove kube-prometheus-stack from Redpanda 1-click app
* Bump to the latest version of Redpanda helm chart v21.5.5

-----------------------------------------------------------------------

## Checklist
- [X] review the [contributing doc](https://github.com/digitalocean/marketplace-kubernetes/blob/master/CONTRIBUTING.md) with steps for both adding or updating your application (if applicable)
------------------------------------------------------------------------

Reviewer: @marketplace-eng
