### PR TITLE
redpanda: Remove bash loop in favour of kubectl wait

### DIFF
--- a/stacks/redpanda/deploy.sh
+++ b/stacks/redpanda/deploy.sh
@@ -48,12 +48,5 @@ helm upgrade "$STACK" "$CHART" \
 MAX=50
 CURRENT=0
 
-until $(kubectl apply -f "https://raw.githubusercontent.com/vectorizedio/redpanda/$CHART_VERSION/src/go/k8s/config/samples/external_connectivity.yaml" >/dev/null 2>&1); do
-  CURRENT=$((CURRENT + 1))
-  sleep 1
-
-  if [ "$CURRENT" -gt "$MAX" ]; then
-    echo "FAILED: Webhook not ready, giving up."
-    exit 1
-  fi
-done
+kubectl wait pod -l app.kubernetes.io/instance=redpanda -n $NAMESPACE --timeout=10m --for condition=ready
+kubectl apply -f "https://raw.githubusercontent.com/vectorizedio/redpanda/$CHART_VERSION/src/go/k8s/config/samples/external_connectivity.yaml"


### PR DESCRIPTION
## BACKGROUND
* When redpanda operator is installed using helm chart there is few second before user can create Cluster CR. For webhook validation, which is invoked during `kubectl apply`, the operator pod need to be up and running. 

-----------------------------------------------------------------------

## Changes
* Change bash loop in favour of `kubectl wait command`

-----------------------------------------------------------------------

## Checklist
- [X] review the [contributing doc](https://github.com/digitalocean/marketplace-kubernetes/blob/master/CONTRIBUTING.md) with steps for both adding or updating your application (if applicable)
------------------------------------------------------------------------

Reviewer: @marketplace-eng
