### PR TITLE
Fix missing context

### DIFF
--- a/stacks/redpanda/deploy.sh
+++ b/stacks/redpanda/deploy.sh
@@ -49,4 +49,5 @@ MAX=50
 CURRENT=0
 
 kubectl wait pod -l app.kubernetes.io/instance=redpanda -n $NAMESPACE --timeout=10m --for condition=ready
+kubectl config set-context --current --namespace default
 kubectl apply -f "https://raw.githubusercontent.com/vectorizedio/redpanda/$CHART_VERSION/src/go/k8s/config/samples/external_connectivity.yaml"


### PR DESCRIPTION
## BACKGROUND
* Last PR #223 tries to fixed the shell loop problem. Unfortunately kubectl is using kubeconfig that has set up namespace to that doesn't exist: https://github.com/digitalocean/marketplace-kubernetes/pull/223#issuecomment-854865831

-----------------------------------------------------------------------

## Changes
* This PR changes kubeconfig namespace to default one where the Redpanda will be installed.

-----------------------------------------------------------------------

## Checklist
- [X] review the [contributing doc](https://github.com/digitalocean/marketplace-kubernetes/blob/master/CONTRIBUTING.md) with steps for both adding or updating your application (if applicable)
------------------------------------------------------------------------

Reviewer: @marketplace-eng
