### PR TITLE
Update 1Password SCIM bridge to v2.1.0

### DIFF
--- a/stacks/op-scim-bridge/deploy.sh
+++ b/stacks/op-scim-bridge/deploy.sh
@@ -7,7 +7,7 @@ helm repo update > /dev/null
 
 STACK="op-scim-bridge"
 CHART="op-scim-bridge/op-scim"
-CHART_VERSION="2.0.2"
+CHART_VERSION="2.1.0"
 NAMESPACE="op-scim-bridge"
 
 helm upgrade "$STACK" "$CHART" \

--- a/stacks/op-scim-bridge/do_config.yml
+++ b/stacks/op-scim-bridge/do_config.yml
@@ -1,0 +1,4 @@
+minimum_resource_requirements:
+  node_count: 2
+  cpu: "1.0"
+  memory: "4Gi"


### PR DESCRIPTION
## BACKGROUND
* 1Password SCIM bridge v2.1.0 was released and we are updating our downstream applications.

-----------------------------------------------------------------------

## Changes
* Update helm chart from v2.0.2 to v2.1.0 

-----------------------------------------------------------------------

## Checklist
- [x] review the [contributing doc](https://github.com/digitalocean/marketplace-kubernetes/blob/master/CONTRIBUTING.md) with steps for both adding or updating your application (if applicable)
- [x] Minimum [resource requirements](https://github.com/digitalocean/marketplace-kubernetes/blob/master/CONTRIBUTING.md#adding-your-application) for your application are up to date. We use this information to prevent applications from being installed on undersized clusters.
------------------------------------------------------------------------

Reviewer: @marketplace-eng
