### PR TITLE
Create remind-vendor-pr-merge.yml

### DIFF
--- a/.github/workflows/remind-vendor-pr-merge.yml
+++ b/.github/workflows/remind-vendor-pr-merge.yml
@@ -1,0 +1,20 @@
+name: Remind Vendor on PR Merge
+
+# only trigger on pull request closed events
+on:
+  pull_request:
+    types: [ closed ]
+
+jobs:
+  merge_job:
+    # this job will only run if the PR has been merged
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: bubkoo/auto-comment@v1
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          pullRequestClosed: >
+            👋 @{{ author }}
+            
+            Your PR is now merged,  please update the version on [vendor portal](https://cloud.digitalocean.com/vendorportal/) so that your changes get reflected on [DigitalOcean Marketplace](https://marketplace.digitalocean.com/apps)


### PR DESCRIPTION
## BACKGROUND
**Reduce time for vendors to get a new PR / update to their DOKS app live, and make sure they don't forget that they need to update Vendor Portal once their PR is merged.

-----------------------------------------------------------------------

## Changes
When the Vendor's PR is merged, automatically remind the Vendor that they need to go to the Vendor Portal to update the PR that's associated with their app, and give them the URL to the Vendor Portal.

-----------------------------------------------------------------------

## Checklist
- [ ] review the [contributing doc](https://github.com/digitalocean/marketplace-kubernetes/blob/master/CONTRIBUTING.md) with steps for both adding or updating your application (if applicable)
- [ ] Minimum [resource requirements](https://github.com/digitalocean/marketplace-kubernetes/blob/master/CONTRIBUTING.md#adding-your-application) for your application are up to date. We use this information to prevent applications from being installed on undersized clusters.
------------------------------------------------------------------------

Reviewer: @marketplace-eng
