### PR TITLE
Remove CHART_VERSION for Posthog Digital Ocean deployment

### DIFF
--- a/stacks/posthog/deploy.sh
+++ b/stacks/posthog/deploy.sh
@@ -13,7 +13,6 @@ helm repo update > /dev/null
 ################################################################################
 STACK="posthog"
 CHART="posthog/posthog"
-CHART_VERSION="1.4.35"
 NAMESPACE="posthog"
 
 if [ -z "${MP_KUBERNETES}" ]; then
@@ -31,5 +30,4 @@ helm upgrade "$STACK" "$CHART" \
   --install \
   --namespace "$NAMESPACE" \
   --values "$values" \
-  --timeout 10m \
-  --version "$CHART_VERSION"
+  --timeout 20m

--- a/stacks/posthog/values.yml
+++ b/stacks/posthog/values.yml
@@ -1,6 +1,7 @@
 cloud: "do"
+deploymentKind: "DigitalOcean 1-click"
 ingress:
   redirectToTLS: false
-  letsencrypt: false 
+  letsencrypt: false
 web:
   secureCookies: false

--- a/stacks/posthog/values.yml
+++ b/stacks/posthog/values.yml
@@ -1,5 +1,5 @@
 cloud: "do"
-deploymentKind: "DigitalOcean 1-click"
+deploymentType: "DigitalOcean 1-click"
 ingress:
   redirectToTLS: false
   letsencrypt: false


### PR DESCRIPTION
## BACKGROUND

Changing to always use the latest chart version instead of hardcoding/pinning a version. Closes https://github.com/PostHog/charts-clickhouse/issues/44 Tested by deploying to a newly created Kubernetes cluster with deploy.sh.

-----------------------------------------------------------------------

## Changes
* removed chart version
* 20m timeout to match the what we have everywhere else in our docs
* add deploymentType value that we report for analytics purposes

-----------------------------------------------------------------------

## Checklist
- [x] review the [contributing doc](https://github.com/digitalocean/marketplace-kubernetes/blob/master/CONTRIBUTING.md) with steps for both adding or updating your application (if applicable)
- [x] Minimum [resource requirements](https://github.com/digitalocean/marketplace-kubernetes/blob/master/CONTRIBUTING.md#adding-your-application) for your application are up to date. We use this information to prevent applications from being installed on undersized clusters.
------------------------------------------------------------------------

Reviewer: @marketplace-eng
