### PR TITLE
Fix Posthog values.yaml and upgrade.sh

### DIFF
--- a/stacks/posthog/upgrade.sh
+++ b/stacks/posthog/upgrade.sh
@@ -5,7 +5,7 @@ set -e
 ################################################################################
 # repo
 ################################################################################
-helm repo add charts-clickhouse https://posthog.github.io/charts-clickhouse/
+helm repo add posthog https://posthog.github.io/charts-clickhouse/
 helm repo update > /dev/null
 
 ################################################################################

--- a/stacks/posthog/values.yml
+++ b/stacks/posthog/values.yml
@@ -1,7 +1,8 @@
 cloud: "do"
 deploymentType: "DigitalOcean 1-click"
 ingress:
-  redirectToTLS: false
+  nginx:
+    redirectToTLS: false
   letsencrypt: false
 web:
   secureCookies: false


### PR DESCRIPTION
## BACKGROUND
* noticed two typos in our setup - fixing them.

-----------------------------------------------------------------------

## Changes
* redirectToTLS was in the wrong place in the values file and hence TLS redirect was enabled by default
* we used posthog as the repo name for helm elsewhere so this makes upgrade.sh script work

Tested by running the `upgrade.sh` script

-----------------------------------------------------------------------

## Checklist
- [x] review the [contributing doc](https://github.com/digitalocean/marketplace-kubernetes/blob/master/CONTRIBUTING.md) with steps for both adding or updating your application (if applicable)
- [x] Minimum [resource requirements](https://github.com/digitalocean/marketplace-kubernetes/blob/master/CONTRIBUTING.md#adding-your-application) for your application are up to date. We use this information to prevent applications from being installed on undersized clusters.
------------------------------------------------------------------------

Reviewer: @marketplace-eng
