### PR TITLE
Add securing Posthog instructions to readme

### DIFF
--- a/stacks/posthog/README.md
+++ b/stacks/posthog/README.md
@@ -21,3 +21,26 @@ echo "Visit http://$INGRESS_IP to use PostHog\!"
 You should now be able to navigate to PostHog at the location printed out to your terminal!
 
 You are now all set up to start trying PostHog!
+
+#### Securing your 1-click install
+
+Sadly it's not possible to provide parameters to DigitalOcean yet, so we need post-install steps to enable TLS.
+
+1. Create a DNS record from your desired hostname to the external IP (`kubectl get --namespace posthog ingress posthog -o jsonpath="{.status.loadBalancer.ingress[0].ip}`).
+2. Create `values.yaml`
+```yaml
+cloud: "do"
+ingress:
+  hostname: <your-hostname>
+  nginx:
+    enabled: true
+certManager:
+  enabled: true
+```
+3. Run the upgrade (note that if you used the UI for install, you'll need to follow the getting started guide to setup kubeconfig, if you skipped it earlier use the "Remind me how to do this" link on the Kubernetes cluster tab)
+
+```console
+helm repo add posthog https://posthog.github.io/charts-clickhouse/
+helm repo update
+helm upgrade -f values.yaml --timeout 20m --namespace posthog posthog posthog/posthog
+```

--- a/stacks/posthog/upgrade.sh
+++ b/stacks/posthog/upgrade.sh
@@ -5,7 +5,7 @@ set -e
 ################################################################################
 # repo
 ################################################################################
-helm repo add charts-clickhouse https://posthog.github.io/charts-clickhouse/
+helm repo add posthog https://posthog.github.io/charts-clickhouse/
 helm repo update > /dev/null
 
 ################################################################################

--- a/stacks/posthog/values.yml
+++ b/stacks/posthog/values.yml
@@ -2,6 +2,7 @@ cloud: "do"
 deploymentType: "DigitalOcean 1-click"
 ingress:
   nginx:
+    enabled: true
     redirectToTLS: false
   letsencrypt: false
 web:

--- a/stacks/posthog/values.yml
+++ b/stacks/posthog/values.yml
@@ -1,7 +1,8 @@
 cloud: "do"
 deploymentType: "DigitalOcean 1-click"
 ingress:
-  redirectToTLS: false
+  nginx:
+    redirectToTLS: false
   letsencrypt: false
 web:
   secureCookies: false


### PR DESCRIPTION
## BACKGROUND

Posthog should be used with TLS, it's currently only possible with post-install steps, those are already documented in the [marketplace page](https://marketplace.digitalocean.com/apps/posthog-1), but added here as well.

-----------------------------------------------------------------------

## Changes
* Add securing posthog instructions to the readme
* update `nginx.enable=true` which is a no-op (I want to change the defaults in our repo https://github.com/PostHog/charts-clickhouse/pull/51 & but we need to set it here first)

-----------------------------------------------------------------------

## Checklist
- [x] review the [contributing doc](https://github.com/digitalocean/marketplace-kubernetes/blob/master/CONTRIBUTING.md) with steps for both adding or updating your application (if applicable)
- [x] Minimum [resource requirements](https://github.com/digitalocean/marketplace-kubernetes/blob/master/CONTRIBUTING.md#adding-your-application) for your application are up to date. We use this information to prevent applications from being installed on undersized clusters.
------------------------------------------------------------------------

Reviewer: @marketplace-eng
