### PR TITLE
update version of kube-prometheus-stack helm chart

### DIFF
--- a/stacks/kube-prometheus-stack/deploy.sh
+++ b/stacks/kube-prometheus-stack/deploy.sh
@@ -13,7 +13,7 @@ helm repo update > /dev/null
 ################################################################################
 STACK="kube-prometheus-stack"
 CHART="prometheus-community/kube-prometheus-stack"
-CHART_VERSION="15.3.1"
+CHART_VERSION="18.0.0"
 NAMESPACE="kube-prometheus-stack"
 
 if [ -z "${MP_KUBERNETES}" ]; then


### PR DESCRIPTION
## BACKGROUND
* Add information about the background and reason for the change.
* This change updates [kube-prometheus-stack helm chart version](https://artifacthub.io/packages/helm/prometheus-community/kube-prometheus-stack/18.0.0) so that users have access to newer features in Prometheus and Grafana. 
-----------------------------------------------------------------------

## Changes
* List the changes that you made
* Update the version of the  kube-prometheus-stack Helm chart from `15.3.1` to `18.0.0`.

-----------------------------------------------------------------------

## Checklist
- [x] review the [contributing doc](https://github.com/digitalocean/marketplace-kubernetes/blob/master/CONTRIBUTING.md) with steps for both adding or updating your application (if applicable)
- [x] Minimum [resource requirements](https://github.com/digitalocean/marketplace-kubernetes/blob/master/CONTRIBUTING.md#adding-your-application) for your application are up to date. We use this information to prevent applications from being installed on undersized clusters.
------------------------------------------------------------------------

Reviewer: @marketplace-eng
