### PR TITLE
cleanup: remove do_config template and requirements

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,7 +10,6 @@
 
 ## Checklist
 - [ ] review the [contributing doc](https://github.com/digitalocean/marketplace-kubernetes/blob/master/CONTRIBUTING.md) with steps for both adding or updating your application (if applicable)
-- [ ] Minimum [resource requirements](https://github.com/digitalocean/marketplace-kubernetes/blob/master/CONTRIBUTING.md#adding-your-application) for your application are up to date. We use this information to prevent applications from being installed on undersized clusters.
 ------------------------------------------------------------------------
 
 Reviewer: @marketplace-eng

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,10 +21,6 @@ export NAMESPACE=$APP_NAME
 
 ./utils/generate-stack.sh
 ```
-4. **Required:** In `do_config.yml`, update minimum resource requirements for your application. We use this information to prevent applications from being installed on undersized clusters. We follow [Kubernetes resource units](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes) standard to define CPU and memory requirements. Update the following parameters under `minimum_resource_requirements`:
-    - `node_count`: minimum number of nodes needed in a cluster to run your application reliably. 
-    - `cpu`: minimum number of CPUs in total cluster capacity needed to power your application.
-    - `memory`: minimum amount of memory in total cluster capacity needed to power your application.
 6. Optionally, customize your `deploy.sh`, `upgrade.sh`, `uninstall.sh` and specify your Helm chart's configuration values in `values.yml`. Both can be found in `stacks/$APP_NAME`
 7. Test out installing your stack by deploying it locally to a k8s cluster: `./stacks/$APP_NAME/deploy.sh`
 8. Test out upgrading your stack by updating it locally on a k8s cluster: `./stacks/$APP_NAME/upgrade.sh`

--- a/utils/stack-templates/do_config.yml
+++ b/utils/stack-templates/do_config.yml
@@ -1,7 +1,0 @@
-# Please read out contributing guide to learn how to properly complete this file.
-# https://github.com/digitalocean/marketplace-kubernetes/blob/master/CONTRIBUTING.md#adding-your-application
-
-minimum_resource_requirements:
-  node_count: 1
-  cpu: "0.5"
-  memory: "64Mi"


### PR DESCRIPTION
## BACKGROUND
removing `do_config` template, since we won't be using it to get app minimum resource requirements from vendors.

-----------------------------------------------------------------------

## Changes
- removed `do_config` template
- removed requirement asking to fill in system requirements

-----------------------------------------------------------------------

## Checklist
- [x] review the [contributing doc](https://github.com/digitalocean/marketplace-kubernetes/blob/master/CONTRIBUTING.md) with steps for both adding or updating your application (if applicable)
------------------------------------------------------------------------

Reviewer: @marketplace-eng
