### PR TITLE
Update OpenEBS Helm Chart from v2.11.0 to v.2.12.0

### DIFF
--- a/stacks/openebs/deploy.sh
+++ b/stacks/openebs/deploy.sh
@@ -13,7 +13,7 @@ helm repo update > /dev/null
 ################################################################################
 STACK="openebs"
 CHART="openebs/openebs"
-CHART_VERSION="2.11.0"
+CHART_VERSION="2.12.0"
 NAMESPACE="openebs"
 
 if [ -z "${MP_KUBERNETES}" ]; then


### PR DESCRIPTION

## BACKGROUND

* Add information about the background and reason for the change.

- Update the OpenEBS version to the latest v2.12.0 from 2.11.0
-----------------------------------------------------------------------

## Changes
* List the changes that you made

- Update CHART_VERSION from 2.11.0 to 2.12.0

-----------------------------------------------------------------------
Signed-off-by: Ranjith R <ranjith.raveendran@mayadata.io>

Reviewer: @marketplace-eng
