### PR TITLE
Bump Redpanda to newly released version v21.8.1

### DIFF
--- a/stacks/redpanda/deploy.sh
+++ b/stacks/redpanda/deploy.sh
@@ -14,7 +14,7 @@ helm repo update > /dev/null
 ################################################################################
 STACK="redpanda"
 CHART="vectorized/redpanda-operator"
-CHART_VERSION="v21.5.5"
+CHART_VERSION="v21.8.1"
 NAMESPACE="redpanda-system"
 
 if [ -z "${MP_KUBERNETES}" ]; then

--- a/stacks/redpanda/uninstall.sh
+++ b/stacks/redpanda/uninstall.sh
@@ -7,9 +7,9 @@ set -x
 ################################################################################
 STACK="redpanda"
 NAMESPACE="redpanda-system"
-CHART_VERSION="v21.5.1"
+CHART_VERSION="v21.8.1"
 
-kubectl delete -f "https://raw.githubusercontent.com/vectorizedio/redpanda/v21.5.1/src/go/k8s/config/samples/external_connectivity.yaml"
+kubectl delete -f "https://raw.githubusercontent.com/vectorizedio/redpanda/v21.8.1/src/go/k8s/config/samples/external_connectivity.yaml"
 
 helm uninstall "$STACK" \
   --namespace "$NAMESPACE"

--- a/stacks/redpanda/upgrade.sh
+++ b/stacks/redpanda/upgrade.sh
@@ -15,7 +15,7 @@ helm repo update > /dev/null
 ################################################################################
 STACK="redpanda"
 CHART="vectorized/redpanda-operator"
-CHART_VERSION="v21.5.1"
+CHART_VERSION="v21.8.1"
 NAMESPACE="redpanda-system"
 
 if [ -z "${MP_KUBERNETES}" ]; then
@@ -43,7 +43,7 @@ helm upgrade "$STACK" "$CHART" \
 --namespace "$NAMESPACE" \
 --values "$values" \
 
-until $(kubectl apply -f "https://raw.githubusercontent.com/vectorizedio/redpanda/v21.5.1/src/go/k8s/config/samples/external_connectivity.yaml" >/dev/null 2>&1); do
+until $(kubectl apply -f "https://raw.githubusercontent.com/vectorizedio/redpanda/v21.8.1/src/go/k8s/config/samples/external_connectivity.yaml" >/dev/null 2>&1); do
   CURRENT=$((CURRENT + 1))
   sleep 1
 


### PR DESCRIPTION
## BACKGROUND
Redpanda got new release [v21.8.1](https://github.com/vectorizedio/redpanda/releases/tag/v21.8.1). 
-----------------------------------------------------------------------

## Changes
Bump every place where version is used
-----------------------------------------------------------------------

## Checklist
- [x] review the [contributing doc](https://github.com/digitalocean/marketplace-kubernetes/blob/master/CONTRIBUTING.md) with steps for both adding or updating your application (if applicable)
------------------------------------------------------------------------

Reviewer: @marketplace-eng
