### PR TITLE
Add Karvdash stack

### DIFF
--- a/stacks/karvdash/deploy.sh
+++ b/stacks/karvdash/deploy.sh
@@ -1,0 +1,174 @@
+#!/bin/sh
+
+set -e
+# set -x
+
+################################################################################
+# repo
+################################################################################
+helm repo add jetstack https://charts.jetstack.io
+helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
+helm repo add csi-driver-nfs https://raw.githubusercontent.com/kubernetes-csi/csi-driver-nfs/master/charts
+helm repo add jupyterhub https://jupyterhub.github.io/helm-chart/
+helm repo add argo https://argoproj.github.io/argo-helm
+helm repo add karvdash https://carv-ics-forth.github.io/karvdash/chart
+helm repo update > /dev/null
+
+################################################################################
+# charts
+################################################################################
+
+get_yaml () {
+    local yaml
+    if [ -z "${MP_KUBERNETES}" ]; then
+        # use local version
+        ROOT_DIR=$(git rev-parse --show-toplevel)
+        yaml="$ROOT_DIR/stacks/karvdash/$1"
+    else
+        # use github hosted master version
+        yaml="https://raw.githubusercontent.com/digitalocean/marketplace-kubernetes/master/stacks/karvdash/$1"
+    fi
+    echo "$yaml"
+}
+
+install_chart () {
+    helm upgrade "$STACK" "$CHART" \
+    --atomic \
+    --timeout 15m0s \
+    --create-namespace \
+    --install \
+    --namespace "$NAMESPACE" \
+    --values "$(get_yaml values/$STACK.yaml)" \
+    --version "$CHART_VERSION" \
+    $EXTRA
+}
+
+INGRESS_NAMESPACE="ingress-nginx"
+JUPYTERHUB_NAMESPACE="jupyterhub"
+ARGO_NAMESPACE="argo"
+
+# cert-manager
+STACK="cert-manager"
+CHART="jetstack/cert-manager"
+CHART_VERSION="v1.1.0"
+NAMESPACE="cert-manager"
+EXTRA=""
+install_chart
+
+# NGINX Ingress Controller
+STACK="ingress"
+CHART="ingress-nginx/ingress-nginx"
+CHART_VERSION="3.19.0"
+NAMESPACE=$INGRESS_NAMESPACE
+EXTRA=""
+install_chart
+
+INGRESS_EXTERNAL_IP=`kubectl -n $NAMESPACE get services ingress-ingress-nginx-controller --output jsonpath='{.status.loadBalancer.ingress[0].ip}'`
+if [ -z "${INGRESS_EXTERNAL_IP}" ]; then
+    # use local IP for testing on Docker Desktop
+    INGRESS_EXTERNAL_IP=$(ipconfig getifaddr en0 || ipconfig getifaddr en1)
+fi
+INGRESS_EXTERNAL_ADDRESS=${INGRESS_EXTERNAL_IP}.nip.io
+
+if kubectl -n $NAMESPACE get secret ssl-certificate; then
+    :
+else
+    export INGRESS_EXTERNAL_ADDRESS
+
+    # retry until ready (https://github.com/jetstack/cert-manager/issues/2908)
+    max_attempts=5
+    for i in $(seq 1 $max_attempts); do
+        envsubst < $(get_yaml yaml/ingress-certificate.yaml) | kubectl -n $NAMESPACE apply -f - && break
+        echo "WARNING: The cert-manager webhook is not ready... Retrying in 5 seconds... (attempt $i/$max_attempts)"
+        sleep 5
+    done
+    if [ $i = $max_attempts ]; then
+        echo "ERROR: The cert-manager webhook failed to initialize after $max_attempts attempts."
+        exit 1;
+    fi
+fi
+
+# NFS CSI Driver
+STACK="csi-driver-nfs"
+CHART="csi-driver-nfs/csi-driver-nfs"
+CHART_VERSION="v3.0.0"
+NAMESPACE="csi-nfs"
+EXTRA=""
+install_chart
+
+# NFS server
+NAMESPACE="nfs"
+
+if kubectl -n $NAMESPACE get service nfs-server; then
+    :
+else
+    kubectl create namespace $NAMESPACE || true
+    kubectl -n $NAMESPACE apply -f $(get_yaml yaml/nfs-service.yaml)
+fi
+
+# Datashim
+kubectl apply -f $(get_yaml yaml/dlf-custom.yaml) # built from 079b99e with "--set csi-nfs-chart.enabled='false'" in HELM_IMAGE_TAGS
+kubectl wait --timeout=600s --for=condition=ready pods -l app.kubernetes.io/name=dlf -n dlf
+
+# Karvdash
+STACK="karvdash"
+CHART="karvdash/karvdash"
+CHART_VERSION="3.0.1"
+NAMESPACE="karvdash"
+EXTRA="--set karvdash.ingressURL=https://${INGRESS_EXTERNAL_ADDRESS} \
+       --set karvdash.filesURL=nfs://nfs-server.nfs.svc/exports \
+       --set karvdash.jupyterHubURL=https://jupyterhub.${INGRESS_EXTERNAL_ADDRESS} \
+       --set karvdash.jupyterHubNamespace=${JUPYTERHUB_NAMESPACE} \
+       --set karvdash.jupyterHubNotebookDir=notebooks \
+       --set karvdash.argoWorkflowsURL=https://argo.${INGRESS_EXTERNAL_ADDRESS} \
+       --set karvdash.argoWorkflowsNamespace=${ARGO_NAMESPACE}"
+
+if kubectl -n $NAMESPACE get pvc karvdash-state-pvc; then
+    :
+else
+    kubectl create namespace $NAMESPACE || true
+    kubectl -n $NAMESPACE apply -f $(get_yaml yaml/karvdash-volume.yaml)
+fi
+
+kubectl create namespace $JUPYTERHUB_NAMESPACE || true
+kubectl create namespace $ARGO_NAMESPACE || true
+
+install_chart
+
+# JupyterHub
+NAMESPACE=$JUPYTERHUB_NAMESPACE
+
+JUPYTERHUB_CLIENT_ID=$(kubectl -n $NAMESPACE get secret karvdash-oauth-jupyterhub -o 'go-template={{index .data "client-id" | base64decode }}')
+JUPYTERHUB_CLIENT_SECRET=$(kubectl -n $NAMESPACE get secret karvdash-oauth-jupyterhub -o 'go-template={{index .data "client-secret" | base64decode }}')
+
+STACK="jupyterhub"
+CHART="jupyterhub/jupyterhub"
+CHART_VERSION="1.0.1"
+EXTRA="--set hub.config.GenericOAuthenticator.client_id=${JUPYTERHUB_CLIENT_ID} \
+       --set hub.config.GenericOAuthenticator.client_secret=${JUPYTERHUB_CLIENT_SECRET} \
+       --set hub.config.GenericOAuthenticator.oauth_callback_url=https://jupyterhub.${INGRESS_EXTERNAL_ADDRESS}/hub/oauth_callback \
+       --set hub.config.GenericOAuthenticator.authorize_url=https://${INGRESS_EXTERNAL_ADDRESS}/oauth/authorize/ \
+       --set hub.config.GenericOAuthenticator.token_url=https://${INGRESS_EXTERNAL_ADDRESS}/oauth/token/ \
+       --set hub.config.GenericOAuthenticator.userdata_url=https://${INGRESS_EXTERNAL_ADDRESS}/oauth/userinfo/ \
+       --set ingress.hosts[0]=jupyterhub.${INGRESS_EXTERNAL_ADDRESS}"
+install_chart
+
+kubectl create clusterrolebinding jupyterhub-cluster-admin --clusterrole=cluster-admin --serviceaccount=$NAMESPACE:hub
+
+# Argo Workflows
+STACK="argo"
+CHART="argo/argo-workflows"
+CHART_VERSION="0.2.12"
+NAMESPACE=$ARGO_NAMESPACE
+EXTRA="--set server.volumeMounts[0].mountPath=/etc/ssl/certs/${INGRESS_EXTERNAL_ADDRESS}.crt \
+       --set server.ingress.hosts[0]=argo.${INGRESS_EXTERNAL_ADDRESS} \
+       --set server.sso.issuer=https://${INGRESS_EXTERNAL_ADDRESS}/oauth \
+       --set server.sso.redirectUrl=https://argo.${INGRESS_EXTERNAL_ADDRESS}/oauth2/callback"
+
+if kubectl -n $NAMESPACE get configmap ssl-certificate; then
+    :
+else
+    kubectl -n $NAMESPACE create configmap ssl-certificate --from-literal="ca.crt=`kubectl get secret ssl-certificate -n ${INGRESS_NAMESPACE} -o 'go-template={{index .data \"ca.crt\" | base64decode }}'`"
+fi
+
+install_chart

--- a/stacks/karvdash/uninstall.sh
+++ b/stacks/karvdash/uninstall.sh
@@ -1,0 +1,83 @@
+#!/bin/sh
+
+set -e
+# set -x
+
+################################################################################
+# charts
+################################################################################
+
+get_yaml () {
+    local yaml
+    if [ -z "${MP_KUBERNETES}" ]; then
+        # use local version
+        ROOT_DIR=$(git rev-parse --show-toplevel)
+        yaml="$ROOT_DIR/stacks/karvdash/$1"
+    else
+        # use github hosted master version
+        yaml="https://raw.githubusercontent.com/digitalocean/marketplace-kubernetes/master/stacks/karvdash/$1"
+    fi
+    echo "$yaml"
+}
+
+uninstall_chart () {
+    helm uninstall "$STACK" --namespace "$NAMESPACE" || true
+    if [ $NAMESPACE != "default" ]; then
+        kubectl delete namespace $NAMESPACE || true
+    fi
+}
+
+# Argo Workflows
+STACK="argo"
+NAMESPACE="argo"
+uninstall_chart
+
+# JupyterHub
+STACK="jupyterhub"
+NAMESPACE="jupyterhub"
+uninstall_chart
+
+kubectl delete clusterrolebinding jupyterhub-cluster-admin
+
+# Karvdash
+STACK="karvdash"
+NAMESPACE="karvdash"
+
+for i in `kubectl get namespaces -o jsonpath='{.items[*].metadata.name}'`; do
+    if echo $i | grep "^karvdash-" > /dev/null; then
+        kubectl delete ns $i # clean up user namespaces
+        for j in `kubectl get pv -o jsonpath='{.items[*].metadata.name}'`; do
+            if echo $j | grep "^$i" > /dev/null; then
+                kubectl delete pv $j # clean up user persistent volumes
+                continue
+            fi
+            if [ "`kubectl get pv $j -o jsonpath='{.spec.claimRef.namespace}'`" = "$i" ]; then
+                kubectl delete pv $j # clean up dataset persistent volumes
+            fi
+        done
+    fi
+done
+
+uninstall_chart
+
+# Datashim
+kubectl delete -f $(get_yaml yaml/dlf-custom.yaml) || true
+
+# NFS server
+NAMESPACE="nfs"
+kubectl delete ns $NAMESPACE || true
+
+# NFS CSI Driver
+STACK="csi-driver-nfs"
+NAMESPACE="csi-nfs"
+uninstall_chart
+
+# NGINX Ingress Controller
+STACK="ingress"
+NAMESPACE="ingress-nginx"
+uninstall_chart
+
+# cert-manager
+STACK="cert-manager"
+NAMESPACE="cert-manager"
+uninstall_chart

--- a/stacks/karvdash/values/argo.yaml
+++ b/stacks/karvdash/values/argo.yaml
@@ -1,0 +1,30 @@
+controller:
+  image:
+    tag: v3.1.1
+  containerRuntimeExecutor: k8sapi
+executor:
+  image:
+    tag: v3.1.1
+server:
+  image:
+    tag: v3.1.1
+  extraArgs:
+  - --auth-mode=sso
+  volumeMounts:
+  - name: ssl-certificate-volume
+    subPath: ca.crt
+  volumes:
+  - name: ssl-certificate-volume
+    configMap:
+      name: ssl-certificate
+  ingress:
+    enabled: true
+  sso:
+    clientId:
+      name: karvdash-oauth-argo
+      key: client-id
+    clientSecret:
+      name: karvdash-oauth-argo
+      key: client-secret
+    rbac:
+      enabled: true

--- a/stacks/karvdash/values/cert-manager.yaml
+++ b/stacks/karvdash/values/cert-manager.yaml
@@ -1,0 +1,1 @@
+installCRDs: true

--- a/stacks/karvdash/values/csi-driver-nfs.yaml
+++ b/stacks/karvdash/values/csi-driver-nfs.yaml
@@ -1,0 +1,2 @@
+controller:
+  replicas: 1

--- a/stacks/karvdash/values/ingress.yaml
+++ b/stacks/karvdash/values/ingress.yaml
@@ -1,0 +1,5 @@
+controller:
+  extraArgs:
+    default-ssl-certificate: ingress-nginx/ssl-certificate
+  admissionWebhooks:
+    enabled: false

--- a/stacks/karvdash/values/jupyterhub.yaml
+++ b/stacks/karvdash/values/jupyterhub.yaml
@@ -1,0 +1,43 @@
+hub:
+  config:
+    JupyterHub:
+      authenticator_class: generic-oauth
+    Authenticator:
+      auto_login: true
+    GenericOAuthenticator:
+      tls_verify: false
+      scope:
+      - openid
+      - profile
+      - email
+      username_key: preferred_username
+  extraConfig:
+    myConfig.py: |
+      c.ConfigurableHTTPProxy.api_url = "http://proxy-api.jupyterhub.svc:8001"
+      c.JupyterHub.hub_connect_url = "http://hub.jupyterhub.svc:8081"
+      c.KubeSpawner.enable_user_namespaces = True
+      c.KubeSpawner.user_namespace_template = "karvdash-{username}"
+      c.KubeSpawner.notebook_dir = "/private/notebooks"
+  networkPolicy:
+    enabled: false
+proxy:
+  service:
+    type: ClusterIP
+  chp:
+    networkPolicy:
+      enabled: false
+singleuser:
+  networkPolicy:
+    enabled: false
+  storage:
+    type: none
+prePuller:
+  hook:
+    enabled: false
+  continuous:
+    enabled: false
+scheduling:
+  userScheduler:
+    enabled: false
+ingress:
+  enabled: true

--- a/stacks/karvdash/values/karvdash.yaml
+++ b/stacks/karvdash/values/karvdash.yaml
@@ -1,0 +1,5 @@
+karvdash:
+  stateVolumeClaim: karvdash-state-pvc
+  datasetsAvailable: 1
+  disabledDatasetTemplates:
+  - s3-local

--- a/stacks/karvdash/yaml/dlf-custom.yaml
+++ b/stacks/karvdash/yaml/dlf-custom.yaml
@@ -1,0 +1,1202 @@
+---
+# Source: dlf-chart/templates/namespace.yaml
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: dlf
+  labels:
+    app.kubernetes.io/name: "dlf"
+---
+# Source: dlf-chart/charts/csi-h3-chart/templates/csi-controller-rbac.yaml
+# This YAML file contains RBAC API objects that are necessary to run external
+# CSI attacher for H3 adapter
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: csi-controller-h3
+  labels:
+    app.kubernetes.io/name: "dlf"
+  namespace: dlf
+---
+# Source: dlf-chart/charts/csi-h3-chart/templates/csi-nodeplugin-rbac.yaml
+# This YAML defines all API objects to create RBAC roles for CSI node plugin
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: csi-nodeplugin-h3
+  labels:
+    app.kubernetes.io/name: "dlf"
+  namespace: dlf
+---
+# Source: dlf-chart/charts/csi-s3-chart/templates/csi-s3.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: csi-s3
+  labels:
+    app.kubernetes.io/name: "dlf"
+  namespace: dlf
+---
+# Source: dlf-chart/charts/csi-sidecars-rbac/templates/attacher-rbac.yaml
+# This YAML file contains all RBAC objects that are necessary to run external
+# CSI attacher.
+#
+# In production, each CSI driver deployment has to be customized:
+# - to avoid conflicts, use non-default namespace and different names
+#   for non-namespaced entities like the ClusterRole
+# - decide whether the deployment replicates the external CSI
+#   attacher, in which case leadership election must be enabled;
+#   this influences the RBAC setup, see below
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: csi-attacher
+  # replace with non-default namespace name
+  namespace: dlf
+  labels:
+    app.kubernetes.io/name: "dlf"
+---
+# Source: dlf-chart/charts/csi-sidecars-rbac/templates/provisioner-rbac.yaml
+# This YAML file contains all RBAC objects that are necessary to run external
+# CSI provisioner.
+#
+# In production, each CSI driver deployment has to be customized:
+# - to avoid conflicts, use non-default namespace and different names
+#   for non-namespaced entities like the ClusterRole
+# - decide whether the deployment replicates the external CSI
+#   provisioner, in which case leadership election must be enabled;
+#   this influences the RBAC setup, see below
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: csi-provisioner
+  # replace with non-default namespace name
+  namespace: dlf
+  labels:
+    app.kubernetes.io/name: "dlf"
+---
+# Source: dlf-chart/charts/dataset-operator-chart/templates/rbac/service_account.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: dataset-operator
+  labels:
+    app.kubernetes.io/name: "dlf"
+  namespace: dlf
+---
+# Source: dlf-chart/charts/dataset-operator-chart/templates/secrets/server-tls.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app.kubernetes.io/name: dlf
+  name: webhook-server-tls
+  namespace: dlf
+type: kubernetes.io/tls
+data:
+  tls.crt: YmFyCg==
+  tls.key: YmFyCg==
+---
+# Source: dlf-chart/charts/csi-h3-chart/templates/csi-h3-storageclass.yaml
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: h3
+  labels:
+    app.kubernetes.io/name: "dlf"
+provisioner: kubernetes.io/no-provisioner
+---
+# Source: dlf-chart/charts/csi-s3-chart/templates/storageclass.yaml
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: csi-s3
+  labels:
+    app.kubernetes.io/name: "dlf"
+provisioner: ch.ctrox.csi.s3-driver
+parameters:
+  # specify which mounter to use
+  # can be set to s3fs, goofys
+  # OTHER OPTIONS NOT WORKING!
+  mounter: goofys
+
+  csi.storage.k8s.io/provisioner-secret-name: ${pvc.name}
+  csi.storage.k8s.io/provisioner-secret-namespace: ${pvc.namespace}
+
+  csi.storage.k8s.io/controller-publish-secret-name: ${pvc.name}
+  csi.storage.k8s.io/controller-publish-secret-namespace: ${pvc.namespace}
+
+  csi.storage.k8s.io/node-stage-secret-name: ${pvc.name}
+  csi.storage.k8s.io/node-stage-secret-namespace: ${pvc.namespace}
+
+  csi.storage.k8s.io/node-publish-secret-name: ${pvc.name}
+  csi.storage.k8s.io/node-publish-secret-namespace: ${pvc.namespace}
+---
+# Source: dlf-chart/charts/dataset-operator-chart/templates/crds/com.ie.ibm.hpsys_datasetinternals_crd.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: datasetsinternal.com.ie.ibm.hpsys
+spec:
+  conversion:
+    strategy: None
+  group: com.ie.ibm.hpsys
+  names:
+    kind: DatasetInternal
+    listKind: DatasetInternalList
+    plural: datasetsinternal
+    singular: datasetinternal
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: DatasetInternal is the Schema for the datasetsinternal API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: DatasetInternalSpec defines the desired state of DatasetInternal
+            properties:
+              local:
+                additionalProperties:
+                  type: string
+                description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
+                  Important: Run "operator-sdk generate k8s" to regenerate code after
+                  modifying this file Add custom validation using kubebuilder tags:
+                  https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html'
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              remote:
+                additionalProperties:
+                  type: string
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            description: DatasetInternalStatus defines the observed state of DatasetInternal
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+# Source: dlf-chart/charts/dataset-operator-chart/templates/crds/com.ie.ibm.hpsys_datasets_crd.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: datasets.com.ie.ibm.hpsys
+spec:
+  conversion:
+    strategy: None
+  group: com.ie.ibm.hpsys
+  names:
+    kind: Dataset
+    listKind: DatasetList
+    plural: datasets
+    singular: dataset
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Dataset is the Schema for the datasets API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: DatasetSpec defines the desired state of Dataset
+            properties:
+              local:
+                additionalProperties:
+                  type: string
+                description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
+                  Important: Run "operator-sdk generate k8s" to regenerate code after
+                  modifying this file Add custom validation using kubebuilder tags:
+                  https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html
+                  Conf map[string]string `json:"conf,omitempty"`'
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              remote:
+                additionalProperties:
+                  type: string
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            description: DatasetStatus defines the observed state of Dataset
+            properties:
+              error:
+                description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
+                  of cluster Important: Run "operator-sdk generate k8s" to regenerate
+                  code after modifying this file Add custom validation using kubebuilder
+                  tags: https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html'
+                type: string
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+# Source: dlf-chart/charts/csi-h3-chart/templates/csi-controller-rbac.yaml
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: external-controller-h3
+  labels:
+    app.kubernetes.io/name: "dlf"
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["csi.storage.k8s.io"]
+    resources: ["csinodeinfos"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+---
+# Source: dlf-chart/charts/csi-h3-chart/templates/csi-controller-rbac.yaml
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-cluster-driver-registrar-role-h3
+  labels:
+    app.kubernetes.io/name: "dlf"
+rules:
+  - apiGroups: ["csi.storage.k8s.io"]
+    resources: ["csidrivers"]
+    verbs: ["create", "delete"]
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["create", "list", "watch", "delete"]
+---
+# Source: dlf-chart/charts/csi-h3-chart/templates/csi-nodeplugin-rbac.yaml
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-nodeplugin-h3
+  labels:
+    app.kubernetes.io/name: "dlf"
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: [""]
+    resources: ["secrets","secret"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+---
+# Source: dlf-chart/charts/csi-s3-chart/templates/csi-s3.yaml
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-s3
+  labels:
+    app.kubernetes.io/name: "dlf"
+  namespace: dlf
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "update"]
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
+    verbs: ["get", "list", "watch", "update","create"]
+---
+# Source: dlf-chart/charts/csi-sidecars-rbac/templates/attacher-rbac.yaml
+# Attacher must be able to work with PVs, CSINodes and VolumeAttachments
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: external-attacher-runner
+  labels:
+    app.kubernetes.io/name: "dlf"
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "update", "patch"] #Adding "update"
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["csinodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
+    verbs: ["get", "list", "watch", "update", "patch", "create"]  #Adding "update"
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments/status"]
+    verbs: ["patch"]
+#Secret permission is optional.
+#Enable it if you need value from secret.
+#For example, you have key `csi.storage.k8s.io/controller-publish-secret-name` in StorageClass.parameters
+#see https://kubernetes-csi.github.io/docs/secrets-and-credentials.html
+#  - apiGroups: [""]
+#    resources: ["secrets"]
+#    verbs: ["get", "list"]
+---
+# Source: dlf-chart/charts/csi-sidecars-rbac/templates/provisioner-rbac.yaml
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: external-provisioner-runner
+  labels:
+    app.kubernetes.io/name: "dlf"
+  namespace: dlf
+rules:
+  # The following rule should be uncommented for plugins that require secrets
+  # for provisioning. #Enabling secrets
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots"]
+    verbs: ["get", "list"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents"]
+    verbs: ["get", "list"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["csinodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch"]
+  # Access to volumeattachments is only needed when the CSI driver
+  # has the PUBLISH_UNPUBLISH_VOLUME controller capability.
+  # In that case, external-provisioner will watch volumeattachments
+  # to determine when it is safe to delete a volume.
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
+    verbs: ["get", "list", "watch","create"]
+---
+# Source: dlf-chart/charts/dataset-operator-chart/templates/rbac/role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: dataset-operator
+  labels:
+    app.kubernetes.io/name: "dlf"
+  namespace: dlf
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - services
+  - endpoints
+  - persistentvolumeclaims
+  - persistentvolumes
+  - events
+  - configmaps
+  - secrets
+  verbs:
+  - '*'
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - daemonsets
+  - replicasets
+  - statefulsets
+  verbs:
+  - '*'
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - get
+  - create
+- apiGroups:
+  - apps
+  resourceNames:
+  - dataset-operator
+  resources:
+  - deployments/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
+- apiGroups:
+  - com.ie.ibm.hpsys
+  resources:
+  - '*'
+  - datasetsinternal
+  verbs:
+  - '*'
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- apiGroups:
+  - objectbucket.io
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- apiGroups:
+    - admissionregistration.k8s.io
+  resources:
+    - mutatingwebhookconfigurations
+  verbs:
+    - '*'
+- apiGroups: ["batch", "extensions"]
+  resources: ["jobs"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+---
+# Source: dlf-chart/charts/csi-h3-chart/templates/csi-controller-rbac.yaml
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-attacher-role-h3
+  labels:
+    app.kubernetes.io/name: "dlf"
+  namespace: dlf
+subjects:
+  - kind: ServiceAccount
+    name: csi-controller-h3
+    namespace: dlf
+roleRef:
+  kind: ClusterRole
+  name: external-controller-h3
+  apiGroup: rbac.authorization.k8s.io
+---
+# Source: dlf-chart/charts/csi-h3-chart/templates/csi-controller-rbac.yaml
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-cluster-driver-registrar-binding-h3
+  labels:
+    app.kubernetes.io/name: "dlf"
+  namespace: dlf
+subjects:
+  - kind: ServiceAccount
+    name: csi-controller-h3
+    namespace: dlf
+roleRef:
+  kind: ClusterRole
+  name: csi-cluster-driver-registrar-role-h3
+  apiGroup: rbac.authorization.k8s.io
+---
+# Source: dlf-chart/charts/csi-h3-chart/templates/csi-nodeplugin-rbac.yaml
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-nodeplugin-h3
+  labels:
+    app.kubernetes.io/name: "dlf"
+  namespace: dlf
+subjects:
+  - kind: ServiceAccount
+    name: csi-nodeplugin-h3
+    namespace: dlf
+roleRef:
+  kind: ClusterRole
+  name: csi-nodeplugin-h3
+  apiGroup: rbac.authorization.k8s.io
+---
+# Source: dlf-chart/charts/csi-s3-chart/templates/csi-s3.yaml
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-s3
+  labels:
+    app.kubernetes.io/name: "dlf"
+  namespace: dlf
+subjects:
+  - kind: ServiceAccount
+    name: csi-s3
+    namespace: dlf
+roleRef:
+  kind: ClusterRole
+  name: csi-s3
+  apiGroup: rbac.authorization.k8s.io
+---
+# Source: dlf-chart/charts/csi-sidecars-rbac/templates/attacher-rbac.yaml
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-attacher-role
+  labels:
+    app.kubernetes.io/name: "dlf"
+subjects:
+  - kind: ServiceAccount
+    name: csi-attacher
+    # replace with non-default namespace name
+    namespace: dlf
+roleRef:
+  kind: ClusterRole
+  name: external-attacher-runner
+  apiGroup: rbac.authorization.k8s.io
+---
+# Source: dlf-chart/charts/csi-sidecars-rbac/templates/provisioner-rbac.yaml
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-provisioner-role
+  labels:
+    app.kubernetes.io/name: "dlf"
+  namespace: dlf
+subjects:
+  - kind: ServiceAccount
+    name: csi-provisioner
+    # replace with non-default namespace name
+    namespace: dlf
+roleRef:
+  kind: ClusterRole
+  name: external-provisioner-runner
+  apiGroup: rbac.authorization.k8s.io
+---
+# Source: dlf-chart/charts/dataset-operator-chart/templates/rbac/role_binding.yaml
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: dataset-operator
+  labels:
+    app.kubernetes.io/name: "dlf"
+  namespace: dlf
+subjects:
+- kind: ServiceAccount
+  name: dataset-operator
+  namespace: dlf
+roleRef:
+  kind: ClusterRole
+  name: dataset-operator
+  apiGroup: rbac.authorization.k8s.io
+---
+# Source: dlf-chart/charts/csi-sidecars-rbac/templates/attacher-rbac.yaml
+# Attacher must be able to work with configmaps or leases in the current namespace
+# if (and only if) leadership election is enabled
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  # replace with non-default namespace name
+  namespace: dlf
+  name: external-attacher-cfg
+  labels:
+    app.kubernetes.io/name: "dlf"
+rules:
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "watch", "list", "delete", "update", "create"]
+---
+# Source: dlf-chart/charts/csi-sidecars-rbac/templates/provisioner-rbac.yaml
+# Provisioner must be able to work with endpoints in current namespace
+# if (and only if) leadership election is enabled
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  # replace with non-default namespace name
+  namespace: dlf
+  name: external-provisioner-cfg
+  labels:
+    app.kubernetes.io/name: "dlf"
+rules:
+  # Only one of the following rules for endpoints or leases is required based on
+  # what is set for `--leader-election-type`. Endpoints are deprecated in favor of Leases.
+  - apiGroups: [""]
+    resources: ["endpoints"]
+    verbs: ["get", "watch", "list", "delete", "update", "create"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "watch", "list", "delete", "update", "create"]
+  # Permissions for CSIStorageCapacity are only needed enabling the publishing
+  # of storage capacity information.
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["csistoragecapacities"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  # The GET permissions below are needed for walking up the ownership chain
+  # for CSIStorageCapacity. They are sufficient for deployment via
+  # StatefulSet (only needs to get Pod) and Deployment (needs to get
+  # Pod and then ReplicaSet to find the Deployment).
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get"]
+  - apiGroups: ["apps"]
+    resources: ["replicasets"]
+    verbs: ["get"]
+---
+# Source: dlf-chart/charts/csi-sidecars-rbac/templates/attacher-rbac.yaml
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-attacher-role-cfg
+  # replace with non-default namespace name
+  namespace: dlf
+  labels:
+    app.kubernetes.io/name: "dlf"
+subjects:
+  - kind: ServiceAccount
+    name: csi-attacher
+    # replace with non-default namespace name
+    namespace: dlf
+roleRef:
+  kind: Role
+  name: external-attacher-cfg
+  apiGroup: rbac.authorization.k8s.io
+---
+# Source: dlf-chart/charts/csi-sidecars-rbac/templates/provisioner-rbac.yaml
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-provisioner-role-cfg
+  # replace with non-default namespace name
+  namespace: dlf
+  labels:
+    app.kubernetes.io/name: "dlf"
+subjects:
+  - kind: ServiceAccount
+    name: csi-provisioner
+    # replace with non-default namespace name
+    namespace: dlf
+roleRef:
+  kind: Role
+  name: external-provisioner-cfg
+  apiGroup: rbac.authorization.k8s.io
+---
+# Source: dlf-chart/charts/csi-s3-chart/templates/attacher.yaml
+# needed for StatefulSet
+kind: Service
+apiVersion: v1
+metadata:
+  name: csi-attacher-s3
+  namespace: dlf
+  labels:
+    app: csi-attacher-s3
+    app.kubernetes.io/name: "dlf"
+spec:
+  selector:
+    app: csi-attacher-s3
+  ports:
+    - name: dummy
+      port: 12345
+---
+# Source: dlf-chart/charts/csi-s3-chart/templates/provisioner.yaml
+kind: Service
+apiVersion: v1
+metadata:
+  name: csi-provisioner-s3
+  namespace: dlf
+  labels:
+    app: csi-provisioner-s3
+    app.kubernetes.io/name: "dlf"
+spec:
+  selector:
+    app: csi-provisioner-s3
+  ports:
+    - name: dummy
+      port: 12345
+---
+# Source: dlf-chart/charts/dataset-operator-chart/templates/apps/operator.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: webhook-server
+  labels:
+    app.kubernetes.io/name: "dlf"
+  namespace: dlf
+spec:
+  selector:
+    name: dataset-operator
+  ports:
+    - port: 443
+      targetPort: webhook-api
+---
+# Source: dlf-chart/charts/csi-h3-chart/templates/csi-nodeplugin-h3.yaml
+# This YAML file contains driver-registrar & csi driver nodeplugin API objects
+# that are necessary to run CSI nodeplugin for H3
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: csi-nodeplugin-h3
+  labels:
+    app.kubernetes.io/name: "dlf"
+  namespace: dlf
+spec:
+  selector:
+    matchLabels:
+      app: csi-nodeplugin-h3
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: "dlf"
+        app: csi-nodeplugin-h3
+    spec:
+      serviceAccountName: csi-nodeplugin-h3
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      containers:
+        - name: node-driver-registrar
+          image: "quay.io/k8scsi/csi-node-driver-registrar:v1.2.0"
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh", "-c", "rm -rf /registration/csi-h3 /registration/csi-h3-reg.sock"]
+          args:
+            - --v=5
+            - --csi-address=/plugin/csi.sock
+            - --kubelet-registration-path=/var/lib/kubelet/plugins/csi-h3/csi.sock
+          env:
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: /plugin
+            - name: registration-dir
+              mountPath: /registration
+        - name: h3
+          securityContext:
+            privileged: true
+            capabilities:
+              add: ["SYS_ADMIN"]
+            allowPrivilegeEscalation: true
+          image: "carvicsforth/csi-h3:v1.2.0"
+          args:
+            - "--nodeid=$(NODE_ID)"
+            - "--endpoint=$(CSI_ENDPOINT)"
+          env:
+            - name: NODE_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: CSI_ENDPOINT
+              value: unix://plugin/csi.sock
+          # imagePullPolicy: "Always"
+          lifecycle:
+            postStart:
+              exec:
+                command: ["/bin/sh", "-c", "mount -t fuse.h3fuse | while read -r mount; do umount $(echo $mount | awk '{print $3}') ; done"]
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: /plugin
+            - name: pods-mount-dir
+              mountPath: /var/lib/kubelet/pods
+              mountPropagation: "Bidirectional"
+      volumes:
+        - name: plugin-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins/csi-h3
+            type: DirectoryOrCreate
+        - name: pods-mount-dir
+          hostPath:
+            path: /var/lib/kubelet/pods
+            type: Directory
+        - hostPath:
+            path: /var/lib/kubelet/plugins_registry
+            type: DirectoryOrCreate
+          name: registration-dir
+---
+# Source: dlf-chart/charts/csi-s3-chart/templates/csi-s3.yaml
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: csi-s3
+  labels:
+    app.kubernetes.io/name: "dlf"
+  namespace: dlf
+spec:
+  selector:
+    matchLabels:
+      app: csi-s3
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: "dlf"
+        app: csi-s3
+    spec:
+      serviceAccountName: csi-s3
+      containers:
+        - name: driver-registrar
+          image: "quay.io/k8scsi/csi-node-driver-registrar:v1.2.0"
+          imagePullPolicy: Always
+          args:
+            - --v=5
+            - --csi-address=/csi/csi.sock
+            - --kubelet-registration-path=/var/lib/kubelet/plugins/csi-s3/csi.sock
+          securityContext:
+            # This is necessary only for systems with SELinux, where
+            # non-privileged sidecar containers cannot access unix domain socket
+            # created by privileged CSI driver container.
+            privileged: true
+          env:
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+          volumeMounts:
+            - mountPath: /csi
+              name: socket-dir
+            - mountPath: /registration
+              name: registration-dir
+        - name: csi-s3
+          image: "quay.io/datashim/csi-s3:latest-amd64"
+          imagePullPolicy: Always
+          args:
+            - "--v=5"
+            - "--endpoint=$(CSI_ENDPOINT)"
+            - "--nodeid=$(KUBE_NODE_NAME)"
+          env:
+            - name: CSI_ENDPOINT
+              value: unix:///csi/csi.sock
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+            - name: cheap
+              value: "off"
+          securityContext:
+            privileged: true
+          #          ports:
+          #            - containerPort: 9898
+          #              name: healthz
+          #              protocol: TCP
+          #          TODO make it configurable and build it for ppc64le
+          #          livenessProbe:
+          #            failureThreshold: 5
+          #            httpGet:
+          #              path: /healthz
+          #              port: healthz
+          #            initialDelaySeconds: 10
+          #            timeoutSeconds: 3
+          #            periodSeconds: 2
+          volumeMounts:
+            - mountPath: /csi
+              name: socket-dir
+            - mountPath: /var/lib/kubelet/pods
+              mountPropagation: Bidirectional
+              name: mountpoint-dir
+            - mountPath: /dev
+              name: dev-dir
+          ##TODO make it configurable and build it for ppc64le
+      #        - name: liveness-probe
+      #          volumeMounts:
+      #            - mountPath: /csi
+      #              name: socket-dir
+      #          image: quay.io/k8scsi/livenessprobe:v1.1.0
+      #          args:
+      #            - --csi-address=/csi/csi.sock
+      #            - --health-port=9898
+      volumes:
+        - hostPath:
+            path: /var/lib/kubelet/plugins/csi-s3
+            type: DirectoryOrCreate
+          name: socket-dir
+        - hostPath:
+            path: /var/lib/kubelet/pods
+            type: DirectoryOrCreate
+          name: mountpoint-dir
+        - hostPath:
+            path: /var/lib/kubelet/plugins_registry
+            type: Directory
+          name: registration-dir
+        - hostPath:
+            path: /dev
+            type: Directory
+          name: dev-dir
+---
+# Source: dlf-chart/charts/dataset-operator-chart/templates/apps/operator.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dataset-operator
+  labels:
+    app.kubernetes.io/name: "dlf"
+  namespace: dlf
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: dataset-operator
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+      labels:
+        name: dataset-operator
+        app.kubernetes.io/name: "dlf"
+    spec:
+      serviceAccountName: dataset-operator
+      initContainers:
+        - name: generate-keys
+          image: "quay.io/datashim/generate-keys:latest-amd64"
+          imagePullPolicy: Always
+          env:
+            - name: DATASET_OPERATOR_NAMESPACE
+              value: dlf
+      containers:
+        - name: dataset-operator
+          # Replace this with the built image name
+          image: "quay.io/datashim/dataset-operator:latest-amd64"
+          command:
+            - dataset-operator
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 8443
+              name: webhook-api
+          env:
+            - name: WATCH_NAMESPACE
+              value: ""
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: OPERATOR_NAME
+              value: "dataset-operator"
+            - name: OPERATOR_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          volumeMounts:
+            - name: webhook-tls-certs
+              mountPath: /run/secrets/tls
+              readOnly: true
+      volumes:
+        - name: webhook-tls-certs
+          secret:
+            secretName: webhook-server-tls
+---
+# Source: dlf-chart/charts/csi-h3-chart/templates/csi-controller-h3.yaml
+# This YAML file contains attacher & csi driver API objects that are necessary
+# to run external CSI attacher for H3
+kind: StatefulSet
+apiVersion: apps/v1
+metadata:
+  name: csi-controller-h3
+  labels:
+    app.kubernetes.io/name: "dlf"
+  namespace: dlf
+spec:
+  serviceName: "csi-controller-h3"
+  replicas: 1
+  selector:
+    matchLabels:
+      app: csi-controller-h3
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: "dlf"
+        app: csi-controller-h3
+    spec:
+      serviceAccountName: csi-controller-h3
+      containers:
+        - name: csi-attacher
+          image: "quay.io/k8scsi/csi-attacher:v2.2.0"
+          args:
+            - "--v=5"
+            - "--csi-address=$(ADDRESS)"
+          env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+          # imagePullPolicy: "Always"
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+        - name: csi-cluster-driver-registrar
+          image: "quay.io/k8scsi/csi-cluster-driver-registrar:v1.0.1"
+          args:
+            - "--v=5"
+            - "--pod-info-mount-version=\"v1\""
+            - "--csi-address=$(ADDRESS)"
+          env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+        - name: h3
+          image: "carvicsforth/csi-h3:v1.2.0"
+          args :
+            - "--nodeid=$(NODE_ID)"
+            - "--endpoint=$(CSI_ENDPOINT)"
+          env:
+            - name: NODE_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: CSI_ENDPOINT
+              value: unix://plugin/csi.sock
+          # imagePullPolicy: "Always"
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /plugin
+      volumes:
+        - name: socket-dir
+          emptyDir:
+---
+# Source: dlf-chart/charts/csi-s3-chart/templates/attacher.yaml
+kind: StatefulSet
+apiVersion: apps/v1
+metadata:
+  name: csi-attacher-s3
+  namespace: dlf
+  labels:
+    app.kubernetes.io/name: "dlf"
+spec:
+  serviceName: "csi-attacher-s3"
+  replicas: 1
+  selector:
+    matchLabels:
+      app: csi-attacher-s3
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: "dlf"
+        app: csi-attacher-s3
+    spec:
+      serviceAccountName: csi-attacher
+      containers:
+        - name: csi-attacher
+          image: "quay.io/k8scsi/csi-attacher:v2.2.0"
+          imagePullPolicy: Always
+          args:
+            - --v=5
+            - --csi-address=/csi/csi.sock
+          securityContext:
+            # This is necessary only for systems with SELinux, where
+            # non-privileged sidecar containers cannot access unix domain socket
+            # created by privileged CSI driver container.
+            privileged: true
+          volumeMounts:
+          - mountPath: /csi
+            name: socket-dir
+
+      volumes:
+        - hostPath:
+            path: /var/lib/kubelet/plugins/csi-s3
+            type: DirectoryOrCreate
+          name: socket-dir
+---
+# Source: dlf-chart/charts/csi-s3-chart/templates/provisioner.yaml
+kind: StatefulSet
+apiVersion: apps/v1
+metadata:
+  name: csi-provisioner-s3
+  labels:
+    app.kubernetes.io/name: "dlf"
+  namespace: dlf
+spec:
+  serviceName: "csi-provisioner-s3"
+  replicas: 1
+  selector:
+    matchLabels:
+      app: csi-provisioner-s3
+  template:
+    metadata:
+      labels:
+        app: csi-provisioner-s3
+    spec:
+      serviceAccountName: csi-provisioner
+      containers:
+        - name: csi-provisioner
+          image: "quay.io/k8scsi/csi-provisioner:v2.0.2"
+          imagePullPolicy: Always
+          args:
+            - -v=5
+            - --csi-address=/csi/csi.sock
+            - --feature-gates=Topology=true
+          securityContext:
+            # This is necessary only for systems with SELinux, where
+            # non-privileged sidecar containers cannot access unix domain socket
+            # created by privileged CSI driver container.
+            privileged: true
+          volumeMounts:
+            - mountPath: /csi
+              name: socket-dir
+      volumes:
+        - hostPath:
+            path: /var/lib/kubelet/plugins/csi-s3
+            type: DirectoryOrCreate
+          name: socket-dir
+---
+# Source: dlf-chart/charts/csi-s3-chart/templates/driver.yaml
+apiVersion: storage.k8s.io/v1
+kind: CSIDriver
+metadata:
+  name: ch.ctrox.csi.s3-driver
+spec:
+  attachRequired: false
+  podInfoOnMount: false
+---
+# Source: dlf-chart/charts/dataset-operator-chart/templates/apps/webhook-definition.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: dlf-mutating-webhook-cfg

--- a/stacks/karvdash/yaml/ingress-certificate.yaml
+++ b/stacks/karvdash/yaml/ingress-certificate.yaml
@@ -5,10 +5,10 @@ metadata:
 spec:
   secretName: ssl-certificate
   duration: 87600h
-  commonName: ${INGRESS_EXTERNAL_ADDRESS}
+  commonName: example.com
   dnsNames:
-  - "${INGRESS_EXTERNAL_ADDRESS}"
-  - "*.${INGRESS_EXTERNAL_ADDRESS}"
+  - "example.com"
+  - "*.example.com"
   privateKey:
     algorithm: RSA
     size: 2048

--- a/stacks/karvdash/yaml/ingress-certificate.yaml
+++ b/stacks/karvdash/yaml/ingress-certificate.yaml
@@ -1,0 +1,23 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: ssl-certificate
+spec:
+  secretName: ssl-certificate
+  duration: 87600h
+  commonName: ${INGRESS_EXTERNAL_ADDRESS}
+  dnsNames:
+  - "${INGRESS_EXTERNAL_ADDRESS}"
+  - "*.${INGRESS_EXTERNAL_ADDRESS}"
+  privateKey:
+    algorithm: RSA
+    size: 2048
+  issuerRef:
+    name: selfsigned
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: selfsigned
+spec:
+  selfSigned: {}

--- a/stacks/karvdash/yaml/karvdash-volume.yaml
+++ b/stacks/karvdash/yaml/karvdash-volume.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: karvdash-state-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+  storageClassName:

--- a/stacks/karvdash/yaml/nfs-service.yaml
+++ b/stacks/karvdash/yaml/nfs-service.yaml
@@ -1,0 +1,60 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: nfs-server
+spec:
+  ports:
+    - name: nfs
+      port: 2049
+    - name: mountd
+      port: 20048
+    - name: rpcbind
+      port: 111
+  selector:
+    app: nfs-server
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nfs-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nfs-server
+  template:
+    metadata:
+      labels:
+        app: nfs-server
+    spec:
+      containers:
+      - name: nfs-server
+        image: gcr.io/google_containers/volume-nfs:0.8
+        ports:
+          - name: nfs
+            containerPort: 2049
+          - name: mountd
+            containerPort: 20048
+          - name: rpcbind
+            containerPort: 111
+        securityContext:
+          privileged: true
+        volumeMounts:
+          - mountPath: /exports
+            name: nfs-server-disk
+      volumes:
+        - name: nfs-server-disk
+          persistentVolumeClaim:
+            claimName: nfs-server-pvc
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: nfs-server-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+  storageClassName:


### PR DESCRIPTION
## BACKGROUND

[Karvdash](https://github.com/CARV-ICS-FORTH/karvdash) is a dashboard service for facilitating data science on Kubernetes. It supplies the landing page for users, allowing them to launch notebooks and other services, design workflows, and specify parameters related to execution through a user-friendly interface. Karvdash manages users, wires up relevant storage to the appropriate paths inside running containers, securely provisions multiple services under one externally-accessible HTTPS endpoint, while keeping them isolated in per-user namespaces at the Kubernetes level, and provides an identity service for OAuth 2.0/OIDC-compatible applications.

This stack installs Karvdash, along with respective dependencies and associated software as a one click-application in DigitalOcean Kubernetes. Upon deployment, users have web-based access to a full-featured software stack, which includes [JupyterHub](https://jupyter.org/hub), [Argo Workflows](https://argoproj.github.io/workflows), as well as [Datashim](https://github.com/datashim-io/datashim) to automatically connect notebooks, workflow and service containers to storage backed by DigitalOcean Spaces.

-----------------------------------------------------------------------

## Changes
* Initial version, based on Karvdash v3.0.1

-----------------------------------------------------------------------

## Checklist
- [x] review the [contributing doc](https://github.com/digitalocean/marketplace-kubernetes/blob/master/CONTRIBUTING.md) with steps for both adding or updating your application (if applicable)
------------------------------------------------------------------------

Reviewer: @marketplace-eng
