### PR TITLE
Update OpenEBS Helm Chart from v2.12.0 to v.3.0.0

### DIFF
--- a/stacks/openebs/deploy.sh
+++ b/stacks/openebs/deploy.sh
@@ -13,7 +13,7 @@ helm repo update > /dev/null
 ################################################################################
 STACK="openebs"
 CHART="openebs/openebs"
-CHART_VERSION="2.12.0"
+CHART_VERSION="3.0.0"
 NAMESPACE="openebs"
 
 if [ -z "${MP_KUBERNETES}" ]; then


### PR DESCRIPTION
## BACKGROUND
- Update the OpenEBS version to the latest v3.0.0 from v2.12.0

-----------------------------------------------------------------------

## Changes
- Update CHART_VERSION from 2.12.0 to 3.0.0
-----------------------------------------------------------------------

Signed-off-by: Ranjith R <ranjith.raveendran@mayadata.io>

Reviewer: @marketplace-eng
