### PR TITLE
1Password SCIM bridge version bump to 2.2.0

### DIFF
--- a/stacks/op-scim-bridge/deploy.sh
+++ b/stacks/op-scim-bridge/deploy.sh
@@ -7,7 +7,7 @@ helm repo update > /dev/null
 
 STACK="op-scim-bridge"
 CHART="op-scim-bridge/op-scim"
-CHART_VERSION="2.1.2"
+CHART_VERSION="2.2.0"
 NAMESPACE="op-scim-bridge"
 
 helm upgrade "$STACK" "$CHART" \


### PR DESCRIPTION
## BACKGROUND
* Bump the 1Password SCIM bridge to v2.1.2

-----------------------------------------------------------------------

## Changes
* https://app-updates.agilebits.com/product_history/SCIM#v202001

-----------------------------------------------------------------------

## Checklist
- [x] review the [contributing doc](https://github.com/digitalocean/marketplace-kubernetes/blob/master/CONTRIBUTING.md) with steps for both adding or updating your application (if applicable)
------------------------------------------------------------------------

Reviewer: @marketplace-eng
