### PR TITLE
chatwoot: remove hardcoded chart version and add timeout

### DIFF
--- a/stacks/chatwoot/deploy.sh
+++ b/stacks/chatwoot/deploy.sh
@@ -14,7 +14,6 @@ helm repo update > /dev/null
 STACK="chatwoot"
 CHART="chatwoot/chatwoot"
 NAMESPACE="chatwoot"
-CHART_VERSION="0.6.4"
 
 if [ -z "${MP_KUBERNETES}" ]; then
   # use local version of values.yml
@@ -31,4 +30,4 @@ helm upgrade "$STACK" "$CHART" \
   --install \
   --namespace "$NAMESPACE" \
   --values "$values" \
-  --version "$CHART_VERSION"
+  --timeout 10m


### PR DESCRIPTION
## BACKGROUND
* 1-click install some time fails if ensuring load balancer exceeds the default 5m helm timeout
* Remove hardcoded chart version to ensure new users are always running latest version of chatwoot

-----------------------------------------------------------------------

## Changes
- Remove hardcoded chart version 
- Add a timeout as sometimes it takes more than default 5min to ensure a load balancer


-----------------------------------------------------------------------

## Checklist
- [x] review the [contributing doc](https://github.com/digitalocean/marketplace-kubernetes/blob/master/CONTRIBUTING.md) with steps for both adding or updating your application (if applicable)
------------------------------------------------------------------------

Fixes https://github.com/chatwoot/chatwoot/issues/3174

Reviewer: @marketplace-eng
