### PR TITLE
bump the chart version number for metrics-server

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,5 @@
 # Contributing
 
-## Updating Version Numberes 
-lkaslkdnflsjdflksdjflksjdflksjldkfj
-
 **Requirement: Your application must be deployable via Helm 3**
 
 To add your application to the [DigitalOcean Marketplace](https://marketplace.digitalocean.com/), you'll need to do the following:


### PR DESCRIPTION
## BACKGROUND
* the helm chart for metrics-server was outdated.

-----------------------------------------------------------------------

## Changes
* updated the helm chart version

-----------------------------------------------------------------------

## Checklist
- [x] review the [contributing doc](https://github.com/digitalocean/marketplace-kubernetes/blob/master/CONTRIBUTING.md) with steps for both adding or updating your application (if applicable)
------------------------------------------------------------------------

Reviewer: @marketplace-eng
