### PR TITLE
Update OpenEBS Helm Chart from `v3.0.0` to `v.3.0.2`

### DIFF
--- a/stacks/openebs/deploy.sh
+++ b/stacks/openebs/deploy.sh
@@ -13,7 +13,7 @@ helm repo update > /dev/null
 ################################################################################
 STACK="openebs"
 CHART="openebs/openebs"
-CHART_VERSION="3.0.0"
+CHART_VERSION="3.0.2"
 NAMESPACE="openebs"
 
 if [ -z "${MP_KUBERNETES}" ]; then


### PR DESCRIPTION
## BACKGROUND
* OpenEBS Helm Chart was outdated.

-----------------------------------------------------------------------

## Changes
* Update OpenEBS Helm Chart version `3.0.0` -> `3.0.2`

-----------------------------------------------------------------------

## Checklist
- [x] review the [contributing doc](https://github.com/digitalocean/marketplace-kubernetes/blob/master/CONTRIBUTING.md) with steps for both adding or updating your application (if applicable)
------------------------------------------------------------------------

Reviewer: @marketplace-eng
