### PR TITLE
Kube state metrics

### DIFF
--- a/stacks/kube-state-metrics/deploy.sh
+++ b/stacks/kube-state-metrics/deploy.sh
@@ -13,7 +13,7 @@ helm repo update > /dev/null
 ################################################################################
 STACK="kube-state-metrics"
 CHART="bitnami/kube-state-metrics"
-CHART_VERSION="0.4.2"
+CHART_VERSION="2.1.13"
 NAMESPACE="kube-system"
 
 if [ -z "${MP_KUBERNETES}" ]; then


### PR DESCRIPTION
## BACKGROUND
This PR updates the version of the kube-state-metrics helm chart. 

-----------------------------------------------------------------------

## Changes
This commit changes the helm chart version of kube-state-metrics from `0.4.2` to `2.1.13` which is the most recent version. 

Information about that helm chart can be found here: https://artifacthub.io/packages/helm/bitnami/kube-state-metrics

-----------------------------------------------------------------------

## Checklist
- [x] review the [contributing doc](https://github.com/digitalocean/marketplace-kubernetes/blob/master/CONTRIBUTING.md) with steps for both adding or updating your application (if applicable)
------------------------------------------------------------------------

Reviewer: @marketplace-eng
