### PR TITLE
Monitoring stack scraping config update

### DIFF
--- a/stacks/kube-prometheus-stack/values.yml
+++ b/stacks/kube-prometheus-stack/values.yml
@@ -4,3 +4,8 @@ grafana:
   persistence:
     enabled: true
     size: 10Gi
+
+prometheus:
+  prometheusSpec:
+    podMonitorSelectorNilUsesHelmValues: false
+    serviceMonitorSelectorNilUsesHelmValues: false


### PR DESCRIPTION
This change configures prometheus to select servicemonitors and podmonitors regardless of their label values.