### PR TITLE
(Trilio) - TrilioVault for Kubernetes v2.6.0 Update

### DIFF
--- a/stacks/triliovault-operator/deploy.sh
+++ b/stacks/triliovault-operator/deploy.sh
@@ -13,7 +13,7 @@ helm repo update > /dev/null
 ################################################################################
 STACK="triliovault-operator"
 CHART="triliovault-operator/k8s-triliovault-operator"
-CHART_VERSION="2.5.0"
+CHART_VERSION="2.6.0"
 NAMESPACE="tvk"
 #HOME=$ROOT_DIR
 
@@ -100,12 +100,12 @@ configure_ui () {
 
   port=$(kubectl get svc k8s-triliovault-ingress-gateway --namespace "$NAMESPACE" -o jsonpath='{.spec.ports[?(@.name=="http")].nodePort}')
 
-  if ! kubectl patch ingress k8s-triliovault-ingress-master --namespace "$NAMESPACE" -p '{"spec":{"rules":[{"host":"'"${tvkhost_name}"'"}]}}';then
+  if ! kubectl patch ingress k8s-triliovault-master --namespace "$NAMESPACE" -p '{"spec":{"rules":[{"host":"'"${tvkhost_name}"'"}]}}';then
     echo "TVK UI configuration failed, please check ingress"
     return 1
   fi
   if ! kubectl patch svc k8s-triliovault-ingress-gateway --namespace "$NAMESPACE" -p '{"spec": {"type": "NodePort"}}' ; then
-    echo "TVK UI configuration failed, please check ingress"
+    echo "TVK UI configuration failed, please check service"
     return 1
   fi
 

--- a/stacks/triliovault-operator/triliovault-manager.yaml
+++ b/stacks/triliovault-operator/triliovault-manager.yaml
@@ -5,7 +5,7 @@ metadata:
     triliovault: triliovault
   name: triliovault-manager
 spec:
-  trilioVaultAppVersion: 2.5.1
+  trilioVaultAppVersion: 2.6.0
   helmVersion:
     version: v3
   applicationScope: Cluster

--- a/stacks/triliovault-operator/upgrade.sh
+++ b/stacks/triliovault-operator/upgrade.sh
@@ -1,0 +1,73 @@
+#!/bin/sh
+
+set -e
+
+################################################################################
+# repo
+################################################################################
+helm repo add triliovault-operator http://charts.k8strilio.net/trilio-stable/k8s-triliovault-operator
+helm repo update > /dev/null
+
+################################################################################
+# TVK Operator chart upgrade
+################################################################################
+STACK="triliovault-operator"
+CHART="triliovault-operator/k8s-triliovault-operator"
+CHART_VERSION="2.6.0"
+NAMESPACE="tvk"
+#HOME=$ROOT_DIR
+
+# Upgrade triliovault operator
+echo "Upgrading Triliovault operator..."
+
+if [ -z "${MP_KUBERNETES}" ]; then
+  # use local version of values.yml
+  ROOT_DIR=$(git rev-parse --show-toplevel)
+  values="$ROOT_DIR/stacks/triliovault-operator/values.yml"
+  TVM="$ROOT_DIR/stacks/$STACK/triliovault-manager.yaml"
+else
+  # use github hosted master version of values.yml
+  values="https://raw.githubusercontent.com/digitalocean/marketplace-kubernetes/master/stacks/triliovault-operator/values.yml"
+  TVM="https://raw.githubusercontent.com/digitalocean/marketplace-kubernetes/master/stacks/triliovault-operator/triliovault-manager.yaml"
+fi
+
+helm upgrade "$STACK" "$CHART" \
+  --atomic \
+  --create-namespace \
+  --install \
+  --namespace "$NAMESPACE" \
+  --values "$values" \
+  --version "$CHART_VERSION"
+
+until (kubectl get pods --namespace "$NAMESPACE" -l "release=triliovault-operator" 2>/dev/null | grep Running); do sleep 3; done
+
+################################################################################
+# TVK Manager Upgrade
+################################################################################
+
+install_tvm () {
+  # Upgrade triliovault manager
+  echo "Upgrading Triliovault manager..."
+
+  kubectl apply -f "$TVM" --namespace "$NAMESPACE"
+  retcode=$?
+
+  if [ "$retcode" -ne 0 ];then
+    echo "Some error occurred during triliovault-manager installation using label definition, please contanct Trilio support"
+    return 1
+  fi
+
+  until (kubectl get pods --namespace "$NAMESPACE" -l "triliovault.trilio.io/owner=triliovault-manager" 2>/dev/null | grep Running); do sleep 3; done
+
+  until (kubectl get pods --namespace "$NAMESPACE" -l app=k8s-triliovault-control-plane 2>/dev/null | grep Running); do sleep 3; done
+
+  until (kubectl get pods --namespace "$NAMESPACE" -l app=k8s-triliovault-admission-webhook 2>/dev/null | grep Running); do sleep 3; done
+
+}
+
+################################################################################
+# TVK one-click upgrade code starts here
+################################################################################
+
+install_tvm
+


### PR DESCRIPTION
## BACKGROUND
* This PR consist of the new product release update of TrilioVault for Kubernetes Operator v2.6.0 and TVK Manager v2.6.0 with its updated deploy.sh and uninstall.sh scripts along with upgrade.sh script for existing users.
-----------------------------------------------------------------------

## Changes
* Updated the installation instructions of TVK Manager using yaml definition for v2.6.0
* 1-click code to configure TVK Management console and how to access it with updated ingress name
* TVK license comes preinstalled with this 1-click release for TVK 2.6.0
* Added the upgrade.sh script for existing users who has TVK 2.5.1 installed
* Added instructions to uninstall both TVK operator and Manager along with TVK license.
-----------------------------------------------------------------------

## Checklist
- [ ] New stack listing - triliovault-operator
- [ ] deploy.sh along with configured management console/TVK UI and preinstalled TVK license.
- [ ] triliovault-manager.yaml
- [ ] upgrade.sh
- [ ] uninstall.sh
------------------------------------------------------------------------

Reviewer: @marketplace-eng