### PR TITLE
Update 1Password SCIM bridge to v2.3.0

### DIFF
--- a/stacks/op-scim-bridge/deploy.sh
+++ b/stacks/op-scim-bridge/deploy.sh
@@ -7,7 +7,7 @@ helm repo update > /dev/null
 
 STACK="op-scim-bridge"
 CHART="op-scim-bridge/op-scim"
-CHART_VERSION="2.2.1"
+CHART_VERSION="2.3.0"
 NAMESPACE="op-scim-bridge"
 
 helm upgrade "$STACK" "$CHART" \


### PR DESCRIPTION
## BACKGROUND
* Update the 1Password SCIM bridge version from v2.2.1 to v2.3.0.

-----------------------------------------------------------------------

## Changes
* [1Password SCIM bridge v2.3.0 changelog](https://app-updates.agilebits.com/product_history/SCIM#v203004)

-----------------------------------------------------------------------

## Checklist
- [x] review the [contributing doc](https://github.com/digitalocean/marketplace-kubernetes/blob/master/CONTRIBUTING.md) with steps for both adding or updating your application (if applicable)
------------------------------------------------------------------------

Reviewer: @marketplace-eng
