### PR TITLE
TrilioVault for Kubernetes release update v2.6.3

### DIFF
--- a/stacks/triliovault-operator/deploy.sh
+++ b/stacks/triliovault-operator/deploy.sh
@@ -13,7 +13,7 @@ helm repo update > /dev/null
 ################################################################################
 STACK="triliovault-operator"
 CHART="triliovault-operator/k8s-triliovault-operator"
-CHART_VERSION="2.6.0"
+CHART_VERSION="2.6.3"
 NAMESPACE="tvk"
 #HOME=$ROOT_DIR
 

--- a/stacks/triliovault-operator/triliovault-manager.yaml
+++ b/stacks/triliovault-operator/triliovault-manager.yaml
@@ -5,7 +5,28 @@ metadata:
     triliovault: triliovault
   name: triliovault-manager
 spec:
-  trilioVaultAppVersion: 2.6.0
-  helmVersion:
-    version: v3
+  trilioVaultAppVersion: 2.6.3
   applicationScope: Cluster
+  # TVK components configuration, currently supports control-plane, web, exporter, web-backend, ingress-controller, admission-webhook.
+  # User can configure resources for all componentes and can configure service type and host for the ingress-controller
+  ingressConfig:
+    ###ingress class and annotation should be uncommented only when ingress controller is set to false below.
+    #ingressClass: "nginx"
+    #annotations:
+    # "key": "value"
+    host: "tvk.doks.com"
+    #tlsSecretName: ssl-certs
+  componentConfiguration:
+    web-backend:
+      resources:
+        requests:
+          memory: "400Mi"
+          cpu: "200m"
+        limits:
+          memory: "2584Mi"
+          cpu: "1000m"
+    ingress-controller:
+      enabled: true
+      service:
+        type: NodePort
+

--- a/stacks/triliovault-operator/upgrade.sh
+++ b/stacks/triliovault-operator/upgrade.sh
@@ -13,7 +13,7 @@ helm repo update > /dev/null
 ################################################################################
 STACK="triliovault-operator"
 CHART="triliovault-operator/k8s-triliovault-operator"
-CHART_VERSION="2.6.0"
+CHART_VERSION="2.6.3"
 NAMESPACE="tvk"
 #HOME=$ROOT_DIR
 


### PR DESCRIPTION
## BACKGROUND
* This PR consist of the new product release update of TrilioVault for Kubernetes Operator v2.6.3 and TVK Manager v2.6.3 with its updated deploy.sh and uninstall.sh scripts along with upgrade.sh script for existing users.
* We have also improved the TVM manager install definition with new parameters to configure requests and limits of web-backend pods and ingress host name.

-----------------------------------------------------------------------

## Changes
1. Updated the installation instructions of TVK Manager using yaml definition for v2.6.3
2. 1-click code to configure TVK Management console and how to access it with updated ingress name from the TVM manager yaml definition
3. TVK license comes preinstalled with this 1-click release for TVK 2.6.3
4. Added the upgrade.sh script for existing users who has TVK 2.5.1 or 2.6.0 installed
5. Added instructions to uninstall both TVK operator and Manager along with TVK license.

-----------------------------------------------------------------------

## Checklist
- [ ] New stack listing - triliovault-operator
- [ ] deploy.sh along with configured management console/TVK UI and preinstalled TVK license.
- [ ] triliovault-manager.yaml
- [ ] upgrade.sh
- [ ] uninstall.sh
------------------------------------------------------------------------

Reviewer: @marketplace-eng
