### PR TITLE
Update version of VictoriaMetrics Cluster and vmagent from  v1.71.0 to v1.72.0

### DIFF
--- a/stacks/victoria-metrics-cluster/README.md
+++ b/stacks/victoria-metrics-cluster/README.md
@@ -34,9 +34,9 @@ across nodes to ensure availability.
 
 | Package  | Version | License |
 | ------------- | ------------- | ------------- |
-| VictoriaMetrics Cluster  | 1.71.0  | Apache 2.0  |
-| vmagent  | 1.71.0  | Apache 2.0  |
-| vmoperator  | 0.22.0  | Apache 2.0  |
+| VictoriaMetrics Cluster  | 1.72.0  | Apache 2.0  |
+| vmagent  | 1.72.0  | Apache 2.0  |
+| vmoperator  | 0.22.1  | Apache 2.0  |
 
 ## Getting started after deploying VictoriaMetrics Cluster
 

--- a/stacks/victoria-metrics-cluster/yaml/vmagent.yaml
+++ b/stacks/victoria-metrics-cluster/yaml/vmagent.yaml
@@ -14,6 +14,6 @@ spec:
   replicaCount: 1
   image:
     repository: victoriametrics/vmagent
-    tag: v1.71.0
+    tag: v1.72.0
   remoteWrite:
     - url: "http://vminsert-vmcluster.default.svc.cluster.local:8480/insert/0/prometheus/api/v1/write"

--- a/stacks/victoria-metrics-cluster/yaml/vmcluster.yaml
+++ b/stacks/victoria-metrics-cluster/yaml/vmcluster.yaml
@@ -8,14 +8,14 @@ spec:
       replicaCount: 2
       image:
         repository: victoriametrics/vmstorage
-        tag: v1.71.0-cluster
+        tag: v1.72.0-cluster
   vmselect:
       replicaCount: 2
       image:
         repository: victoriametrics/vmselect
-        tag: v1.71.0-cluster
+        tag: v1.72.0-cluster
   vminsert:
       replicaCount: 2
       image:
         repository: victoriametrics/vminsert
-        tag: v1.71.0-cluster
+        tag: v1.72.0-cluster


### PR DESCRIPTION
## BACKGROUND
* Update version of VictoriaMetrics Cluster and vmagent from  v1.71.0 to v1.72.0

-----------------------------------------------------------------------

## Changes
* VictoriaMetrics [CHANGELOG v1.72.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.72.0)

-----------------------------------------------------------------------

## Checklist
- [x] review the [contributing doc](https://github.com/digitalocean/marketplace-kubernetes/blob/master/CONTRIBUTING.md) with steps for both adding or updating your application (if applicable)
------------------------------------------------------------------------

Reviewer: @marketplace-eng
