### PR TITLE
Update 1Password SCIM bridge to 2.3.1

### DIFF
--- a/stacks/op-scim-bridge/deploy.sh
+++ b/stacks/op-scim-bridge/deploy.sh
@@ -7,8 +7,9 @@ helm repo update > /dev/null
 
 STACK="op-scim-bridge"
 CHART="op-scim-bridge/op-scim"
-CHART_VERSION="2.3.0"
+CHART_VERSION="2.3.1"
 NAMESPACE="op-scim-bridge"
+STORAGE_CLASS="do-block-storage"
 
 helm upgrade "$STACK" "$CHART" \
   --atomic \
@@ -16,5 +17,5 @@ helm upgrade "$STACK" "$CHART" \
   --timeout 8m0s \
   --create-namespace \
   --namespace "$NAMESPACE" \
-  --version "$CHART_VERSION"
-
+  --version "$CHART_VERSION" \
+  --set scim.credentialsVolume.storageClass="$STORAGE_CLASS"


### PR DESCRIPTION
## BACKGROUND
* In this release we update the 1Password SCIM bridge to version 2.3.1.

-----------------------------------------------------------------------

## Changes
* We now set the storage class (`scim.credentialsVolume.storageClass`) during the install/upgrade instead of using a hardcoded value in the Helm chart.
* We also fixed a bug where the service was named `op-scim-bridge-bridge-svc` instead of `op-scim-bridge-bridge-svc`.

-----------------------------------------------------------------------

## Checklist
- [x] review the [contributing doc](https://github.com/digitalocean/marketplace-kubernetes/blob/master/CONTRIBUTING.md) with steps for both adding or updating your application (if applicable)
------------------------------------------------------------------------

Reviewer: @marketplace-eng
