### PR TITLE
Trilio - TVK 2.7.0 - Change to fetch latest TVK chart version

### DIFF
--- a/stacks/triliovault-operator/deploy.sh
+++ b/stacks/triliovault-operator/deploy.sh
@@ -55,7 +55,7 @@ until (kubectl get pods --namespace "$NAMESPACE" -l "release=triliovault-operato
 
 until (kubectl get pods --namespace "$NAMESPACE" -l "triliovault.trilio.io/owner=triliovault-manager" 2>/dev/null | grep Running); do sleep 3; done
 until (kubectl get pods --namespace "$NAMESPACE" -l app=k8s-triliovault-exporter 2>/dev/null | grep 1/1); do sleep 3; done
-until (kubectl get pods --namespace "$NAMESPACE" -l app=k8s-triliovault-ingress-nginx-controller 2>/dev/null | grep 1/1); do sleep 3; done
+until (kubectl get pods --namespace "$NAMESPACE" -l "app.kubernetes.io/name=k8s-triliovault-ingress-nginx" 2>/dev/null | grep 1/1); do sleep 3; done
 until (kubectl get pods --namespace "$NAMESPACE" -l app=k8s-triliovault-web 2>/dev/null | grep 1/1); do sleep 3; done
 until (kubectl get pods --namespace "$NAMESPACE" -l app=k8s-triliovault-web-backend 2>/dev/null | grep 1/1); do sleep 3; done
 until (kubectl get pods --namespace "$NAMESPACE" -l app=k8s-triliovault-control-plane 2>/dev/null | grep 2/2); do sleep 3; done

--- a/stacks/triliovault-operator/deploy.sh
+++ b/stacks/triliovault-operator/deploy.sh
@@ -55,7 +55,7 @@ until (kubectl get pods --namespace "$NAMESPACE" -l "release=triliovault-operato
 
 until (kubectl get pods --namespace "$NAMESPACE" -l "triliovault.trilio.io/owner=triliovault-manager" 2>/dev/null | grep Running); do sleep 3; done
 until (kubectl get pods --namespace "$NAMESPACE" -l app=k8s-triliovault-exporter 2>/dev/null | grep 1/1); do sleep 3; done
-until (kubectl get pods --namespace "$NAMESPACE" -l app=k8s-triliovault-ingress-gateway 2>/dev/null | grep 1/1); do sleep 3; done
+until (kubectl get pods --namespace "$NAMESPACE" -l app=k8s-triliovault-ingress-nginx-controller 2>/dev/null | grep 1/1); do sleep 3; done
 until (kubectl get pods --namespace "$NAMESPACE" -l app=k8s-triliovault-web 2>/dev/null | grep 1/1); do sleep 3; done
 until (kubectl get pods --namespace "$NAMESPACE" -l app=k8s-triliovault-web-backend 2>/dev/null | grep 1/1); do sleep 3; done
 until (kubectl get pods --namespace "$NAMESPACE" -l app=k8s-triliovault-control-plane 2>/dev/null | grep 2/2); do sleep 3; done
@@ -71,21 +71,21 @@ access_tvk_ui () {
   echo "################################################################################"
   echo "TVK UI will be configured with NodePort but if you are not able to access it, please run below command to use port-forward from the machine you are accessing the TVK UI from."
   echo ""
-  echo "kubectl port-forward --address 0.0.0.0 svc/k8s-triliovault-ingress-gateway --namespace $NAMESPACE 80:80 &"
+  echo "kubectl port-forward --address 0.0.0.0 svc/k8s-triliovault-ingress-nginx-controller --namespace $NAMESPACE 80:80 &"
   echo ""
   echo "Copy & paste the above command into the terminal session and TVK management console traffic will be forwarded to your localhost IP of 127.0.0.1 via port 80."
   echo "Provide the kubeconfig file which can be downloaded from DOKS cluster UI"
   echo "################################################################################"
   echo ""
 
-  gateway=$(kubectl get pods --no-headers=true --namespace "$NAMESPACE" 2>/dev/null | awk '/k8s-triliovault-ingress-gateway/{print $1}')
+  controller=$(kubectl get pods --no-headers=true --namespace "$NAMESPACE" 2>/dev/null | awk '/k8s-triliovault-ingress-nginx-controller/{print $1}')
 
-  if [ -z "$gateway" ]; then
-    echo "Not able to find k8s-triliovault-ingress-gateway resource,TVK UI configuration failed"
+  if [ -z "$controller" ]; then
+    echo "Not able to find k8s-triliovault-ingress-nginx-controller resource,TVK UI configuration failed"
     return 1
   fi
 
-  node=$(kubectl get pods "$gateway" --namespace "$NAMESPACE" -o jsonpath='{.spec.nodeName}')
+  node=$(kubectl get pods "$controller" --namespace "$NAMESPACE" -o jsonpath='{.spec.nodeName}')
   ip=$(kubectl get node "$node" --namespace "$NAMESPACE" -o jsonpath='{.status.addresses[?(@.type=="ExternalIP")].address}')
 
   if [ -z "$ip" ]; then
@@ -93,7 +93,7 @@ access_tvk_ui () {
     ip=$(kubectl get node "$node" --namespace "$NAMESPACE" -o jsonpath='{.status.addresses[?(@.type=="InternalIP")].address}')
   fi
 
-  port=$(kubectl get svc k8s-triliovault-ingress-gateway --namespace "$NAMESPACE" -o jsonpath='{.spec.ports[?(@.name=="http")].nodePort}')
+  port=$(kubectl get svc k8s-triliovault-ingress-nginx-controller --namespace "$NAMESPACE" -o jsonpath='{.spec.ports[?(@.name=="http")].nodePort}')
 
   echo ""
   echo "################################################################################"
@@ -164,4 +164,3 @@ fi
 
 access_tvk_ui
 install_license
-

--- a/stacks/triliovault-operator/deploy.sh
+++ b/stacks/triliovault-operator/deploy.sh
@@ -13,7 +13,7 @@ helm repo update > /dev/null
 ################################################################################
 STACK="triliovault-operator"
 CHART="triliovault-operator/k8s-triliovault-operator"
-LATEST="$(curl -s https://charts.k8strilio.net/trilio-stable/k8s-triliovault-operator/index.yaml | grep -m 1 appVersion | awk -F ':' '{gsub(/ /,""); print $2 }')"
+LATEST="$(helm show chart triliovault-operator/k8s-triliovault-operator | grep appVersion | awk -F ':' '{gsub(/ /,""); print $2 }')"
 echo "Installing TVK version: $LATEST"
 CHART_VERSION=$LATEST
 NAMESPACE="tvk"

--- a/stacks/triliovault-operator/deploy.sh
+++ b/stacks/triliovault-operator/deploy.sh
@@ -13,7 +13,9 @@ helm repo update > /dev/null
 ################################################################################
 STACK="triliovault-operator"
 CHART="triliovault-operator/k8s-triliovault-operator"
-CHART_VERSION="latest"
+LATEST="$(curl -s https://charts.k8strilio.net/trilio-stable/k8s-triliovault-operator/index.yaml | grep -m 1 appVersion | awk -F ':' '{gsub(/ /,""); print $2 }')"
+echo "Installing TVK version: $LATEST"
+CHART_VERSION=$LATEST
 NAMESPACE="tvk"
 #HOME=$ROOT_DIR
 INSTALL_TVM=true

--- a/stacks/triliovault-operator/triliovault-manager.yaml
+++ b/stacks/triliovault-operator/triliovault-manager.yaml
@@ -5,7 +5,7 @@ metadata:
     triliovault: triliovault
   name: triliovault-manager
 spec:
-  trilioVaultAppVersion: 2.6.7
+  trilioVaultAppVersion: 2.7.0
   applicationScope: Cluster
   # TVK components configuration, currently supports control-plane, web, exporter, web-backend, ingress-controller, admission-webhook.
   # User can configure resources for all componentes and can configure service type and host for the ingress-controller

--- a/stacks/triliovault-operator/upgrade.sh
+++ b/stacks/triliovault-operator/upgrade.sh
@@ -13,7 +13,9 @@ helm repo update > /dev/null
 ################################################################################
 STACK="triliovault-operator"
 CHART="triliovault-operator/k8s-triliovault-operator"
-CHART_VERSION="latest"
+LATEST="$(curl -s https://charts.k8strilio.net/trilio-stable/k8s-triliovault-operator/index.yaml | grep -m 1 appVersion | awk -F ':' '{gsub(/ /,""); print $2 }')"
+echo "Installing TVK version: $LATEST"
+CHART_VERSION=$LATEST
 NAMESPACE="tvk"
 #HOME=$ROOT_DIR
 

--- a/stacks/triliovault-operator/upgrade.sh
+++ b/stacks/triliovault-operator/upgrade.sh
@@ -13,7 +13,7 @@ helm repo update > /dev/null
 ################################################################################
 STACK="triliovault-operator"
 CHART="triliovault-operator/k8s-triliovault-operator"
-LATEST="$(curl -s https://charts.k8strilio.net/trilio-stable/k8s-triliovault-operator/index.yaml | grep -m 1 appVersion | awk -F ':' '{gsub(/ /,""); print $2 }')"
+LATEST="$(helm show chart triliovault-operator/k8s-triliovault-operator | grep appVersion | awk -F ':' '{gsub(/ /,""); print $2 }')"
 echo "Upgrading TVK to latest version: $LATEST"
 CHART_VERSION=$LATEST
 NAMESPACE="tvk"

--- a/stacks/triliovault-operator/upgrade.sh
+++ b/stacks/triliovault-operator/upgrade.sh
@@ -14,7 +14,7 @@ helm repo update > /dev/null
 STACK="triliovault-operator"
 CHART="triliovault-operator/k8s-triliovault-operator"
 LATEST="$(curl -s https://charts.k8strilio.net/trilio-stable/k8s-triliovault-operator/index.yaml | grep -m 1 appVersion | awk -F ':' '{gsub(/ /,""); print $2 }')"
-echo "Installing TVK version: $LATEST"
+echo "Upgrading TVK to latest version: $LATEST"
 CHART_VERSION=$LATEST
 NAMESPACE="tvk"
 #HOME=$ROOT_DIR
@@ -71,7 +71,7 @@ install_tvm () {
 
   until (kubectl get pods --namespace "$NAMESPACE" -l "triliovault.trilio.io/owner=triliovault-manager" 2>/dev/null | grep Running); do sleep 3; done
   until (kubectl get pods --namespace "$NAMESPACE" -l app=k8s-triliovault-exporter 2>/dev/null | grep 1/1); do sleep 3; done
-  until (kubectl get pods --namespace "$NAMESPACE" -l app=k8s-triliovault-ingress-gateway 2>/dev/null | grep 1/1); do sleep 3; done
+  until (kubectl get pods --namespace "$NAMESPACE" -l app=k8s-triliovault-ingress-nginx-controller 2>/dev/null | grep 1/1); do sleep 3; done
   until (kubectl get pods --namespace "$NAMESPACE" -l app=k8s-triliovault-web 2>/dev/null | grep 1/1); do sleep 3; done
   until (kubectl get pods --namespace "$NAMESPACE" -l app=k8s-triliovault-web-backend 2>/dev/null | grep 1/1); do sleep 3; done
   until (kubectl get pods --namespace "$NAMESPACE" -l app=k8s-triliovault-control-plane 2>/dev/null | grep 2/2); do sleep 3; done

--- a/stacks/triliovault-operator/upgrade.sh
+++ b/stacks/triliovault-operator/upgrade.sh
@@ -58,8 +58,7 @@ install_tvm () {
   echo "Upgrading Triliovault manager..."
   
   # Replace TVM.yaml with latest version
-  UPGRADE_VERSION=$(helm show chart triliovault-operator/k8s-triliovault-operator | grep appVersion | awk -F ':' '{gsub(/ /,""); print $2 }')
-  sed -i '/^spec:/{n;s/trilioVaultAppVersion:.*/trilioVaultAppVersion: '$UPGRADE_VERSION'/;}' $ROOT_DIR/stacks/$STACK/triliovault-manager.yaml
+  sed -i '/^spec:/{n;s/trilioVaultAppVersion:.*/trilioVaultAppVersion: '$LATEST'/;}' $ROOT_DIR/stacks/$STACK/triliovault-manager.yaml
 
   kubectl apply -f "$TVM" --namespace "$NAMESPACE"
   retcode=$?
@@ -71,7 +70,7 @@ install_tvm () {
 
   until (kubectl get pods --namespace "$NAMESPACE" -l "triliovault.trilio.io/owner=triliovault-manager" 2>/dev/null | grep Running); do sleep 3; done
   until (kubectl get pods --namespace "$NAMESPACE" -l app=k8s-triliovault-exporter 2>/dev/null | grep 1/1); do sleep 3; done
-  until (kubectl get pods --namespace "$NAMESPACE" -l app=k8s-triliovault-ingress-nginx-controller 2>/dev/null | grep 1/1); do sleep 3; done
+  until (kubectl get pods --namespace "$NAMESPACE" -l "app.kubernetes.io/name=k8s-triliovault-ingress-nginx" 2>/dev/null | grep 1/1); do sleep 3; done
   until (kubectl get pods --namespace "$NAMESPACE" -l app=k8s-triliovault-web 2>/dev/null | grep 1/1); do sleep 3; done
   until (kubectl get pods --namespace "$NAMESPACE" -l app=k8s-triliovault-web-backend 2>/dev/null | grep 1/1); do sleep 3; done
   until (kubectl get pods --namespace "$NAMESPACE" -l app=k8s-triliovault-control-plane 2>/dev/null | grep 2/2); do sleep 3; done


### PR DESCRIPTION
## BACKGROUND
1. This PR consist of the change in `deploy.sh` and `upgrade.sh` file
2. The change is only to fetch the latest version of the TVK operator
3. Earlier the version was being fetched from the `chartmuseum` repo which might have internal test builds there like alpha and beta so wanted to avoid a situation where customer might down those internal builds.

-----------------------------------------------------------------------

## Changes
Change to fetch latest version of TVK operator from the helm repo

-----------------------------------------------------------------------

## Checklist
- [ ] deploy.sh
- [ ] upgrade.sh
------------------------------------------------------------------------

Reviewer: @marketplace-eng
