### PR TITLE
Adds --force-update flag for ambassador repo add

### DIFF
--- a/stacks/ambassador/deploy.sh
+++ b/stacks/ambassador/deploy.sh
@@ -5,7 +5,7 @@ set -e
 ################################################################################
 # repo
 ################################################################################
-helm repo add datawire https://app.getambassador.io
+helm repo add datawire https://app.getambassador.io --force-update
 helm repo update > /dev/null
 
 ################################################################################


### PR DESCRIPTION
## BACKGROUND
* Add information about the background and reason for the change.
Ambassador 1-Click install fails due to:
https://helm.sh/docs/faq/troubleshooting/#helm-repo-add-fails-when-it-used-to-work

## Changes
Added the `--force-update` flag to the Ambassador `deploy.sh` script. If everything goes well with this fix, we can apply this to all apps.

-----------------------------------------------------------------------

## Checklist
- [x] review the [contributing doc](https://github.com/digitalocean/marketplace-kubernetes/blob/master/CONTRIBUTING.md) with steps for both adding or updating your application (if applicable)
------------------------------------------------------------------------

Reviewer: @marketplace-eng
