### PR TITLE
Bump Netdata Helm Chart to 3.7.19 (Agent v1.35.1)

### DIFF
--- a/stacks/netdata/deploy.sh
+++ b/stacks/netdata/deploy.sh
@@ -13,7 +13,7 @@ helm repo update > /dev/null
 ################################################################################
 STACK="netdata"
 CHART="netdata/netdata"
-CHART_VERSION="3.6.7"
+CHART_VERSION="3.7.19"
 NAMESPACE="netdata"
 
 if [ -z "${MP_KUBERNETES}" ]; then


### PR DESCRIPTION
## BACKGROUND
* Keep Netdata up to date.

-----------------------------------------------------------------------

## Changes
* This PR bumps Netdata Helm Chart to the latest stable version (3.7.19).

-----------------------------------------------------------------------

## Checklist
- [X] review the [contributing doc](https://github.com/digitalocean/marketplace-kubernetes/blob/master/CONTRIBUTING.md) with steps for both adding or updating your application (if applicable)
------------------------------------------------------------------------

Reviewer: @marketplace-eng
