### PR TITLE
Update 1Password/op-scim-bridge to v2.5.0

### DIFF
--- a/stacks/op-scim-bridge/deploy.sh
+++ b/stacks/op-scim-bridge/deploy.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-helm repo add op-scim-bridge https://raw.githubusercontent.com/1Password/op-scim-helm/main/
+helm repo add op-scim-bridge https://1password.github.io/op-scim-helm
 helm repo update > /dev/null
 
 STACK="op-scim-bridge"

--- a/stacks/op-scim-bridge/deploy.sh
+++ b/stacks/op-scim-bridge/deploy.sh
@@ -2,16 +2,20 @@
 
 set -e
 
-helm repo add op-scim-bridge https://1password.github.io/op-scim-helm
+REPO_URL="https://1password.github.io/op-scim-helm"
+REPO_NAME="1password"
+
+helm repo add "$REPO_NAME" "$REPO_URL"
 helm repo update > /dev/null
 
-STACK="op-scim-bridge"
-CHART="op-scim-bridge/op-scim"
-CHART_VERSION="2.4.1"
+CHART_NAME="op-scim-bridge"
+CHART_VERSION="2.5.0"
+
+RELEASE="op-scim-bridge"
 NAMESPACE="op-scim-bridge"
 STORAGE_CLASS="do-block-storage"
 
-helm upgrade "$STACK" "$CHART" \
+helm upgrade "$RELEASE" "$REPO_NAME/$CHART_NAME" \
   --atomic \
   --install \
   --timeout 8m0s \


### PR DESCRIPTION
## BACKGROUND
* In this release we update the Helm repo URL. The underlying repository is still the same, but we have since migrated to using the [Helm chart releaser action](https://helm.sh/docs/howto/chart_releaser_action/) to automate the tagging and releasing of the 1Password/op-scim-bridge chart.

-----------------------------------------------------------------------

## Changes
* Update `1password/op-scim-bridge` Chart URL and version
* Rename some of the variables in `deploy.sh` for clarity
* Introduce additional variables in `deploy.sh` for clarity
* Chart includes [1Password SCIM bridge v2.4.1](https://app-updates.agilebits.com/product_history/SCIM#v204011)
* Chart includes dependency bitnami/redis v16.13.2 (i.e. redis v6.2.7)
* Note that we are no longer keeping the 1password/op-scim-bridge Chart version and SCIM bridge app version in lockstep. For example, the chart version for this release is 2.5.0 and the app version is 2.4.1.

-----------------------------------------------------------------------

## Checklist
- [x] review the [contributing doc](https://github.com/digitalocean/marketplace-kubernetes/blob/master/CONTRIBUTING.md) with steps for both adding or updating your application (if applicable)
------------------------------------------------------------------------

Reviewer: @marketplace-eng
