### PR TITLE
Upgrades Starter kit and blueprints apps versions

### DIFF
--- a/stacks/ambassador/README.md
+++ b/stacks/ambassador/README.md
@@ -19,7 +19,7 @@ The DigitalOcean 1-click application installs the [Helm 3](https://helm.sh/docs/
 
 | Package               | Application Version   | Helm Chart Version |License                                                                                    |
 | ---| ---- | ---- | ------------- |
-| Ambassador Edge Stack | 2.1.2 | [7.2.2](https://artifacthub.io/packages/helm/datawire/edge-stack/7.2.2) | [Apache 2.0](https://github.com/datawire/ambassador/blob/master/LICENSE) |
+| Ambassador Edge Stack | 2.2.2 | [7.3.2](https://artifacthub.io/packages/helm/datawire/edge-stack/7.3.2) | [Apache 2.0](https://github.com/datawire/ambassador/blob/master/LICENSE) |
 
 ## Getting Started
 
@@ -44,7 +44,7 @@ If the installation was successful, the `STATUS` column value in the output read
 
 ```text
 NAME       NAMESPACE  REVISION UPDATED                              STATUS   CHART            APP VERSION
-edge-stack ambassador 1        2022-02-14 18:02:21.554041 +0200 EET deployed edge-stack-7.2.2 2.1.2
+edge-stack ambassador 1        2022-02-14 18:02:21.554041 +0200 EET deployed edge-stack-7.3.2 2.2.2
 ```
 
 Next, verify that the Ambassador Ingress pods are up and running with the following command:
@@ -92,13 +92,13 @@ The Ambassador Ingress stack provides some custom values to start with. Please h
 You can always inspect all the available options, as well as the default values for the Ambassador Ingress Helm chart by running below command:
 
 ```console
-helm show values datawire/edge-stack --version 7.2.2
+helm show values datawire/edge-stack --version 7.3.2
 ```
 
 After tweaking the Helm values file (`values.yml`) according to your needs, you can always apply the changes via `helm upgrade` command, as shown below:
 
 ```console
-helm upgrade edge-stack datawire/edge-stack --version 7.2.2 \
+helm upgrade edge-stack datawire/edge-stack --version 7.3.2 \
   --namespace ambassador \
   --values values.yml
 ```
@@ -131,7 +131,7 @@ And then the following `delete` commands:
 ```bash
 kubectl delete ns ambassador
 
-kubectl delete -f https://app.getambassador.io/yaml/edge-stack/2.1.2/aes-crds.yaml
+kubectl delete -f https://app.getambassador.io/yaml/edge-stack/2.3.0/aes-crds.yaml
 ```
 
 ### Additional Resources

--- a/stacks/ambassador/deploy.sh
+++ b/stacks/ambassador/deploy.sh
@@ -13,7 +13,7 @@ helm repo update > /dev/null
 ################################################################################
 STACK="edge-stack"
 CHART="datawire/edge-stack"
-CHART_VERSION="7.2.2"
+CHART_VERSION="7.3.2"
 NAMESPACE="ambassador"
 
 if [ -z "${MP_KUBERNETES}" ]; then
@@ -26,7 +26,7 @@ else
 fi
 
 # Before installing Ambassador 2.X itself, you must configure your Kubernetes cluster to support the getambassador.io/v3alpha1 and getambassador.io/v2 configuration resources. This is required.
-kubectl apply -f https://app.getambassador.io/yaml/edge-stack/2.1.2/aes-crds.yaml
+kubectl apply -f https://app.getambassador.io/yaml/edge-stack/2.3.0/aes-crds.yaml
 
 helm upgrade "$STACK" "$CHART" \
   --atomic \

--- a/stacks/ambassador/values.yml
+++ b/stacks/ambassador/values.yml
@@ -1,5 +1,5 @@
 ## Stack name: datawire/edge-stack
-## Ref: https://github.com/emissary-ingress/emissary/tree/chart/v7.2.2/charts/emissary-ingress
+## Ref: https://github.com/emissary-ingress/emissary/tree/chart/v7.3.2/charts/emissary-ingress
 ##
 
 # Deployment replica count

--- a/stacks/argocd/README.md
+++ b/stacks/argocd/README.md
@@ -44,7 +44,7 @@ Below diagram shows how Argo CD manages Helm applications hosted using a Git rep
 
 | Package | Argo CD Version | Helm Chart Version | License |
 |---------|-----------------| ------------------ |-------- |
-| Argo CD | [2.3.1](https://github.com/argoproj/argo-cd/releases/tag/v2.3.1) | [4.2.1](https://github.com/argoproj/argo-helm/releases/tag/argo-cd-4.2.1) |[Apache 2.0](https://github.com/argoproj/argo-cd/blob/master/LICENSE) |
+| Argo CD | [2.4.0](https://github.com/argoproj/argo-cd/releases/tag/v2.4.0) | [4.9.4](https://github.com/argoproj/argo-helm/releases/tag/argo-cd-4.9.4) |[Apache 2.0](https://github.com/argoproj/argo-cd/blob/master/LICENSE) |
 
 ## Getting Started
 
@@ -64,7 +64,7 @@ The output looks similar to the following:
 
 ```text
 NAME    NAMESPACE       REVISION        UPDATED                                 STATUS          CHART           APP VERSION
-argocd  argocd          1               2022-04-04 17:45:41.52626 +0300 EEST    deployed        argo-cd-4.2.1   v2.3.1 
+argocd  argocd          1               2022-04-04 17:45:41.52626 +0300 EEST    deployed        argo-cd-4.9.4   v2.4.0 
 ```
 
 The `STATUS` column value should be `deployed`.
@@ -99,13 +99,13 @@ The argocd stack provides some custom values to start with. See the [values](./v
 You can inspect all the available options, as well as the default values for the argo-cd Helm chart by running the following command:
 
 ```console
-helm show values argo/argo-cd --version 4.2.1
+helm show values argo/argo-cd --version 4.9.4
 ```
 
 After customizing the Helm values file (`values.yml`), you can apply the changes via the `helm upgrade` command, as shown below:
 
 ```console
-helm upgrade argocd argo/argo-cd --version 4.2.1 \
+helm upgrade argocd argo/argo-cd --version 4.9.4 \
   --namespace argocd \
   --values values.yml
 ```

--- a/stacks/argocd/deploy.sh
+++ b/stacks/argocd/deploy.sh
@@ -13,7 +13,7 @@ helm repo update > /dev/null
 ################################################################################
 STACK="argocd"
 CHART="argo/argo-cd"
-CHART_VERSION="4.2.1"
+CHART_VERSION="4.9.4"
 NAMESPACE="argocd"
 
 if [ -z "${MP_KUBERNETES}" ]; then

--- a/stacks/argocd/values.yml
+++ b/stacks/argocd/values.yml
@@ -1,5 +1,5 @@
 ## Chart: argo/argo-cd
-## Ref: https://github.com/argoproj/argo-helm/tree/argo-cd-4.2.1/charts/argo-cd
+## Ref: https://github.com/argoproj/argo-helm/tree/argo-cd-4.9.4/charts/argo-cd
 ##
 
 # Main Argo CD server replica count

--- a/stacks/cert-manager/README.md
+++ b/stacks/cert-manager/README.md
@@ -20,7 +20,7 @@ The following diagram shows how Cert-Manager works in conjunction with the Nginx
 
 | Package | Cert-Manager Version | Helm Chart Version | License |
 |---------|----------------------|--------------------|---------|
-| Cert-Manager | [1.6.1](https://github.com/cert-manager/cert-manager/releases/tag/v1.6.1) | [1.6.1](https://artifacthub.io/packages/helm/cert-manager/cert-manager/1.6.1) | [Apache 2.0](https://github.com/cert-manager/cert-manager/blob/master/LICENSE) |
+| Cert-Manager | [1.8.0](https://github.com/cert-manager/cert-manager/releases/tag/v1.8.0) | [1.8.0](https://artifacthub.io/packages/helm/cert-manager/cert-manager/1.8.0) | [Apache 2.0](https://github.com/cert-manager/cert-manager/blob/master/LICENSE) |
 
 ## Getting Started
 
@@ -45,7 +45,7 @@ If the installation was successful, the `STATUS` column value in the output read
 
 ```text
 NAME            NAMESPACE       REVISION        UPDATED                                 STATUS          CHART                   APP VERSION
-cert-manager    cert-manager    1               2022-02-21 18:49:08.264191 +0200 EET    deployed        cert-manager-v1.6.1     v1.6.1
+cert-manager    cert-manager    1               2022-02-21 18:49:08.264191 +0200 EET    deployed        cert-manager-v1.8.0     v1.8.0
 ```
 
 Next, verify that the Cert-Manager pods are up and running with the following command:
@@ -70,13 +70,13 @@ The `cert-manager` has custom default Helm values. See the [values](./values.yml
 To inspect its current values, run the following command:
 
 ```console
-helm show values jetstack/cert-manager --version 1.6.1
+helm show values jetstack/cert-manager --version 1.8.0
 ```
 
 To change these values, open the Helm values file `values.yml`, change whatever values you want, save and exit the file, and apply the changes by running `helm upgrade` command:
 
 ```console
-helm upgrade cert-manager jetstack/cert-manager --version 1.6.1 \
+helm upgrade cert-manager jetstack/cert-manager --version 1.8.0 \
   --namespace cert-manager \
   --values values.yml
 ```

--- a/stacks/cert-manager/deploy.sh
+++ b/stacks/cert-manager/deploy.sh
@@ -13,7 +13,7 @@ helm repo update > /dev/null
 ################################################################################
 STACK="cert-manager"
 CHART="jetstack/cert-manager"
-CHART_VERSION="1.6.1"
+CHART_VERSION="1.8.0"
 NAMESPACE="cert-manager"
 
 if [ -z "${MP_KUBERNETES}" ]; then

--- a/stacks/cert-manager/values.yml
+++ b/stacks/cert-manager/values.yml
@@ -1,5 +1,5 @@
 ## Chart: jetstack/cert-manager
-## Ref: https://github.com/cert-manager/cert-manager/blob/v1.6.1/deploy/charts/cert-manager/
+## Ref: https://github.com/cert-manager/cert-manager/blob/v1.8.0/deploy/charts/cert-manager/
 ##
 
 # Cert-Manager requires a number of CRD resources to be installed beforehand

--- a/stacks/ingress-nginx/README.md
+++ b/stacks/ingress-nginx/README.md
@@ -46,8 +46,8 @@ helm ls -n ingress-nginx
 The output looks similar to the following:
 
 ```text
-NAME         	NAMESPACE    	REVISION	UPDATED                             	STATUS  	CHART                     	APP VERSION
-ingress-nginx	ingress-nginx	1       	2022-04-18 18:12:41.623665 -0400 EDT	deployed	ingress-nginx-4.1.0-beta.1	1.2.0-beta.1
+NAME            NAMESPACE       REVISION        UPDATED                                 STATUS          CHART                   APP VERSION
+ingress-nginx   ingress-nginx   1               2022-08-02 10:55:25.064553 +0300 EEST   deployed        ingress-nginx-4.1.3     1.2.1 
 ```
 
 The `STATUS` column value should be `deployed`.
@@ -82,9 +82,9 @@ ingress-nginx-controller             LoadBalancer   10.245.156.128   67.207.70.1
 ingress-nginx-controller-admission   ClusterIP      10.245.18.58     <none>          443/TCP                      3m
 ingress-nginx-controller-metrics     ClusterIP      10.245.193.76    <none>          10254/TCP                    3m
 ```
- 
+
 Check that the `EXTERNAL-IP` column has a valid IP address.
- 
+
 ### Tweaking Helm Values
 
 The NGINX Ingress stack provides some custom values to start with. See the [values](./values.yml) file from the main GitHub repository for more information.

--- a/stacks/ingress-nginx/values.yml
+++ b/stacks/ingress-nginx/values.yml
@@ -1,5 +1,5 @@
 ## Stack name: ingress-nginx/ingress-nginx
-## Ref: https://github.com/kubernetes/ingress-nginx/tree/helm-chart-4.0.13/charts/ingress-nginx/
+## Ref: https://github.com/kubernetes/ingress-nginx/tree/helm-chart-4.1.3/charts/ingress-nginx/
 ##
 
 controller:

--- a/stacks/knative/README.md
+++ b/stacks/knative/README.md
@@ -1,6 +1,5 @@
 # Description
 
-
 [Knative](https://knative.dev) is an open-source solution to build and deploy serverless applications using Kubernetes as the underlying platform. In addition to application development, developers may also have infrastructure tasks such as maintaining Kubernetes manifests for application deployment, rolling back to a previous revision, traffic routing, scaling up or down workloads to meet load demand, etc. Knative reduces the boilerplate needed for spinning up workloads in Kubernetes, such as creating deployments, services, ingress objects, etc. Knative also helps you implement best practices in production systems (e.g. blue-green, canary deployments), application observability (logs and metrics), and support for event-driven applications.
 
 Knative comprises of two main components:
@@ -44,9 +43,9 @@ Minimum system requirements for Knative are as follows:
 
 | Package | Application Version | License |
 |---------|---------------------|---------|
-| Knative Operator | [1.2.2](https://github.com/knative/operator/releases/tag/knative-v1.2.2) | [Apache 2.0](https://github.com/knative/operator/blob/main/LICENSE) |
-| Knative Serving | [1.2.3](https://github.com/knative/serving/releases/tag/knative-v1.2.3) | [Apache 2.0](https://github.com/knative/serving/blob/main/LICENSE) |
-| Knative Eventing | [0.26.3](https://github.com/knative/eventing/releases/tag/v0.26.3) | [Apache 2.0](https://github.com/knative/eventing/blob/main/LICENSE) |
+| Knative Operator | [1.5.1](https://github.com/knative/operator/releases/tag/knative-v1.5.1) | [Apache 2.0](https://github.com/knative/operator/blob/main/LICENSE) |
+| Knative Serving | [1.5.0](https://github.com/knative/serving/releases/tag/knative-v1.5.0) | [Apache 2.0](https://github.com/knative/serving/blob/main/LICENSE) |
+| Knative Eventing | [1.5.0](https://github.com/knative/eventing/releases/tag/knative-v1.5.0) | [Apache 2.0](https://github.com/knative/eventing/blob/main/LICENSE) |
 
 ## Getting Started
 
@@ -85,11 +84,11 @@ Serving is one of the main components of Knative. Check if it is running by usin
 kubectl get KnativeServing knative-serving -n knative-serving
 ```
 
-The output looks similar to the following: 
+The output looks similar to the following:
 
 ```text
 NAME              VERSION   READY   REASON
-knative-serving   1.2.3     True
+knative-serving   1.5.0     True
 ```
 
 The `READY` column should have a value of `True`.
@@ -129,7 +128,7 @@ The output looks similar to:
 
 ```text
 NAME               VERSION   READY   REASON
-knative-eventing   0.26.3    True
+knative-eventing   1.5.0    True
 ```
 
 Then, run the following command to check if all Knative Eventing deployments are healthy:
@@ -187,7 +186,7 @@ kind: KnativeServing
 metadata:
   name: knative-serving
 spec:
-  version: "1.2.3"
+  version: "1.5.0"
   ingress:
     kourier:
       enabled: true
@@ -198,7 +197,7 @@ spec:
 
 Explanations for the above configuration:
 
-- `spec.version`: Tells Knative Operator what version of `KnativeServing` to install in your DOKS cluster (for example, `1.2.3`).
+- `spec.version`: Tells Knative Operator what version of `KnativeServing` to install in your DOKS cluster (for example, `1.5.0`).
 - `spec.ingress` and `spec.config.network`: Tells Knative what implementation to use for the networking layer (for example, Kourier).
 
 In the previous example, Knative uses Kourier as the default networking implementation to handle ingress configuration. You can also choose other available options such as Istio and Contour. Note that Kourier is the option which comes bundled with Knative. For the other networking implementations mentioned earlier, you need to install the stacks separately. For example, install the Istio stack.
@@ -224,10 +223,10 @@ metadata:
   name: knative-eventing
   namespace: knative-eventing
 spec:
-  version: "0.26.3"
+  version: "1.5.0"
 ```
 
-In the previous configuration, the Knative Operator installs the `0.26.3` version of `KnativeEventing` component in your DOKS cluster, via the `spec.version` field. If no version is specified, then the latest one available is picked automatically. You can also configure other options like message broker configurations, resources requests and limits for the underlying containers, etc.
+In the previous configuration, the Knative Operator installs the `1.5.0` version of `KnativeEventing` component in your DOKS cluster, via the `spec.version` field. If no version is specified, then the latest one available is picked automatically. You can also configure other options like message broker configurations, resources requests and limits for the underlying containers, etc.
 
 **Note:**
 
@@ -323,7 +322,7 @@ If you do not have a real DNS setup yet, you can quickly test the service by cre
     ```
 
     The `EXTERNAL-IP` column gives you the Kourier ingress controller's public IP address.
-    
+
 2. Create a new entry for your Knative service in the `/etc/hosts` file by replacing the `<>` placeholders:
 
     ```text
@@ -337,7 +336,7 @@ If you do not have a real DNS setup yet, you can quickly test the service by cre
     ```
 
 It takes several seconds for Knative to cold start your serverless application.
- 
+
 4. Get specific information about each resource type in the `knative-samples` namespace using the `kn` command:
 
 - List available `services`:
@@ -417,6 +416,29 @@ kubectl apply -f <YOUR_KNATIVE_EVENTING_MANIFEST_FILE>
 ```
 
 See [Upgrade via the Knative Operator Guide](https://knative.dev/docs/install/upgrade/upgrade-installation-with-operator) for more information on how to upgrade the components, as well as the allowed migration paths.
+
+**Notes:**
+Please also note that if you attempt to upgrade from version `0.x.x` to version `1.x.x` you will get a message in the `knative operator` informing you that: `Version migration is not eligible with message: not supported to upgrade or downgrade across the MAJOR version.` To upgrade to a `MAJOR` version you should remove the existing `Knative Serving` or `Knative Eventing` resources and add new ones as follows:
+
+First remove the Knative Serving resource:
+
+  ```console
+  kubectl delete KnativeServing knative-serving -n knative-serving
+  ```
+
+  or Knative Eventing resource:
+
+  ```console
+  kubectl delete KnativeEventing knative-eventing -n knative-eventing
+  ```
+
+Next, add a new major version in the `spec.version` field of the Eventing/Serving CRDs shown above and apply with `kubectl`:
+
+```console
+kubectl apply -f <YOUR_KNATIVE_SERVING_MANIFEST_FILE>
+
+kubectl apply -f <YOUR_KNATIVE_EVENTING_MANIFEST_FILE>
+```
 
 ## Uninstalling Knative
 

--- a/stacks/knative/assets/manifests/knative-eventing.yaml
+++ b/stacks/knative/assets/manifests/knative-eventing.yaml
@@ -9,4 +9,4 @@ metadata:
   name: knative-eventing
   namespace: knative-eventing
 spec:
-  version: "0.26.3"
+  version: "1.5.0"

--- a/stacks/knative/assets/manifests/knative-serving.yaml
+++ b/stacks/knative/assets/manifests/knative-serving.yaml
@@ -9,7 +9,7 @@ metadata:
   name: knative-serving
   namespace: knative-serving
 spec:
-  version: "1.2.3"
+  version: "1.5.0"
   ingress:
     kourier:
       enabled: true

--- a/stacks/knative/deploy.sh
+++ b/stacks/knative/deploy.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-OPERATOR_VERSION="1.2.2"
+OPERATOR_VERSION="1.5.1"
 
 if [ -z "${MP_KUBERNETES}" ]; then
   # use local version of knative serving and eventing manifests

--- a/stacks/knative/uninstall.sh
+++ b/stacks/knative/uninstall.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-OPERATOR_VERSION="1.2.2"
+OPERATOR_VERSION="1.5.1"
 
 # Remove Knative Serving and Eventing resources first
 kubectl delete KnativeServing knative-serving -n knative-serving

--- a/stacks/kube-prometheus-stack/README.md
+++ b/stacks/kube-prometheus-stack/README.md
@@ -38,7 +38,7 @@ The diagram below shows a simple example for backend services monitoring, as wel
 
 | Package | Prometheus Version | Prometheus Operator Version | Helm Chart Version | License |
 |---------|--------------------|-----------------------------| ------------------ |-------- |
-| Kubernetes Prometheus Stack | [2.32.1](https://github.com/prometheus/prometheus/releases/tag/v2.32.1) | [0.53.1](https://github.com/prometheus-operator/prometheus-operator/releases/tag/v0.53.1) | [30.0.1](https://github.com/prometheus-community/helm-charts/releases/tag/kube-prometheus-stack-30.0.1)  | [Apache 2.0](https://github.com/prometheus-operator/kube-prometheus/blob/main/LICENSE) |
+| Kubernetes Prometheus Stack | [2.34.0](https://github.com/prometheus/prometheus/releases/tag/v2.34.0) | [0.56.3](https://github.com/prometheus-operator/prometheus-operator/releases/tag/v0.56.3) | [35.5.1](https://github.com/prometheus-community/helm-charts/releases/tag/kube-prometheus-stack-35.5.1)  | [Apache 2.0](https://github.com/prometheus-operator/kube-prometheus/blob/main/LICENSE) |
 
 ## Getting Started
 
@@ -58,7 +58,7 @@ The output looks similar to the following:
 
 ```text
 NAME                    NAMESPACE               REVISION  UPDATED               STATUS    CHART                         APP VERSION
-kube-prometheus-stack   kube-prometheus-stack   1         2022-02-16 16:02:48   deployed  kube-prometheus-stack-30.0.1  0.53.1
+kube-prometheus-stack   kube-prometheus-stack   1         2022-02-16 16:02:48   deployed  kube-prometheus-stack-35.5.1  0.56.3
 ```
 
 The `STATUS` column value should be `deployed`.
@@ -101,7 +101,8 @@ You can connect to Grafana by port forwarding the `kube-prometheus-stack-grafana
 ```console
 kubectl port-forward svc/kube-prometheus-stack-grafana 3000:80 -n kube-prometheus-stack
 ```
-Use the default credentials: `admin/prom-operator` as specified in the [values.yml](values.yml#L52). 
+
+Use the default credentials: `admin/prom-operator` as specified in the [values.yml](values.yml#L52).
 
 Next, launch a web browser of your choice, and enter the following URL: http://localhost:3000. You can take a look around, and see what dashboards are available for you to use from the [kubernetes-mixin](https://github.com/kubernetes-monitoring/kubernetes-mixin) project as an example, by navigating to the following URL: http://localhost:3000/dashboards?tag=kubernetes-mixin.
 
@@ -112,13 +113,13 @@ The `kube-prometheus-stack` provides some custom values to start with. See the [
 You can inspect all the available options, as well as the default values for the `kube-prometheus-stack` Helm chart by running the following command:
 
 ```console
-helm show values prometheus-community/kube-prometheus-stack --version 30.0.1
+helm show values prometheus-community/kube-prometheus-stack --version 35.5.1
 ```
 
 After customizing the Helm values file (`values.yml`), you can apply the changes via the `helm upgrade` command, as shown below:
 
 ```console
-helm upgrade kube-prometheus-stack prometheus-community/kube-prometheus-stack --version 30.0.1 \
+helm upgrade kube-prometheus-stack prometheus-community/kube-prometheus-stack --version 35.5.1 \
   --namespace kube-prometheus-stack \
   --values values.yml
 ```
@@ -168,7 +169,7 @@ After adding required services to monitor, you need to upgrade the stack via the
 
 ```console
 helm upgrade kube-prometheus-stack prometheus-community/kube-prometheus-stack \
-  --version 30.0.1 \
+  --version 35.5.1 \
   --namespace kube-prometheus-stack \
   --values values.yml
 ```

--- a/stacks/kube-prometheus-stack/deploy.sh
+++ b/stacks/kube-prometheus-stack/deploy.sh
@@ -13,7 +13,7 @@ helm repo update > /dev/null
 ################################################################################
 STACK="kube-prometheus-stack"
 CHART="prometheus-community/kube-prometheus-stack"
-CHART_VERSION="30.0.1"
+CHART_VERSION="35.5.1"
 NAMESPACE="kube-prometheus-stack"
 
 if [ -z "${MP_KUBERNETES}" ]; then

--- a/stacks/kube-prometheus-stack/values.yml
+++ b/stacks/kube-prometheus-stack/values.yml
@@ -1,5 +1,5 @@
 ## Stack name: prometheus-community/kube-prometheus-stack
-## Ref: https://github.com/prometheus-community/helm-charts/tree/kube-prometheus-stack-30.0.1/charts/kube-prometheus-stack
+## Ref: https://github.com/prometheus-community/helm-charts/tree/kube-prometheus-stack-35.5.1/charts/kube-prometheus-stack
 ##
 
 

--- a/stacks/loki/README.md
+++ b/stacks/loki/README.md
@@ -24,7 +24,7 @@ A Loki-based logging stack consists of 3 components:
 
 | Package               | Application Version   | Helm Chart Version |License                                                                                    |
 | ---| ---- | ---- | ------------- |
-| Loki Stack | 2.1.0 | [2.5.1](https://artifacthub.io/packages/helm/grafana/loki-stack/2.5.1) | [Apache 2.0](https://github.com/grafana/loki/blob/main/LICENSE) |
+| Loki Stack | 2.6.3 | [2.1.0](https://artifacthub.io/packages/helm/grafana/loki-stack/2.6.3) | [Apache 2.0](https://github.com/grafana/loki/blob/main/LICENSE) |
 
 ## Getting Started
 
@@ -49,7 +49,7 @@ If the installation was successful, the `STATUS` column value in the output read
 
 ```text
 NAME NAMESPACE  REVISION UPDATED                              STATUS   CHART            APP VERSION
-loki loki-stack 1        2022-02-16 14:47:29.497728 +0200 EET deployed loki-stack-2.5.1 v2.1.0
+loki loki-stack 1        2022-02-16 14:47:29.497728 +0200 EET deployed loki-stack-2.6.3 v2.1.0
 ```
 
 Next, verify that the Loki pods are up and running with the following command:
@@ -93,7 +93,7 @@ The `loki-stack` has custom default Helm values. See the [values](./values.yml) 
 To inspect the stack's current values, run the following command:
 
 ```console
-helm show values grafana/loki-stack --version 2.5.1
+helm show values grafana/loki-stack --version 2.6.3
 ```
 
 To change these values, open the Helm values file `values.yml`, change whatever values you want, save and exit the file, and apply the changes by running `helm upgrade` command:
@@ -112,7 +112,7 @@ To upgrade the stack to a newer version, run the following command, replacing th
 
 ```console
 helm upgrade loki grafana/loki-stack \
-  --version <KUBE_Loki_STACK_NEW_VERSION> \
+  --version <KUBE_LOKI_STACK_NEW_VERSION> \
   --namespace loki-stack \
   --values <YOUR_HELM_VALUES_FILE>
 ```

--- a/stacks/loki/deploy.sh
+++ b/stacks/loki/deploy.sh
@@ -13,7 +13,7 @@ helm repo update > /dev/null
 ################################################################################
 STACK="loki"
 CHART="grafana/loki-stack"
-CHART_VERSION="2.5.1"
+CHART_VERSION="2.6.3"
 NAMESPACE="loki-stack"
 
 if [ -z "${MP_KUBERNETES}" ]; then

--- a/stacks/loki/values.yml
+++ b/stacks/loki/values.yml
@@ -1,5 +1,5 @@
 ## Stack name: grafana/loki-stack
-## Ref: https://artifacthub.io/packages/helm/grafana/loki-stack/2.5.1
+## Ref: https://artifacthub.io/packages/helm/grafana/loki-stack/2.6.4
 ##
 
 loki:

--- a/stacks/loki/values.yml
+++ b/stacks/loki/values.yml
@@ -1,5 +1,5 @@
 ## Stack name: grafana/loki-stack
-## Ref: https://artifacthub.io/packages/helm/grafana/loki-stack/2.6.4
+## Ref: https://artifacthub.io/packages/helm/grafana/loki-stack/2.6.3
 ##
 
 loki:

--- a/stacks/wordpress/README.md
+++ b/stacks/wordpress/README.md
@@ -14,7 +14,7 @@ This DigitalOcean Marketplace Kubernetes 1-Click installs [WordPress](https://gi
 | Package               | Application Version   | Helm Chart Version |License                                                                                    |
 | ---| ---- | ---- | ------------- |
 | WordPress | 6.0.1 | [15.0.11](https://artifacthub.io/packages/helm/bitnami/wordpress/15.0.11) | [GPLv2](https://wordpress.org/about/license/) |
-| MariaDB | 10.6.8 | [15.0.11](https://artifacthub.io/packages/helm/bitnami/wordpress/1.0.22) | [GPLv2](https://mariadb.com/kb/en/library/mariadb-license/) |
+| MariaDB | 10.6.8 | [15.0.11](https://artifacthub.io/packages/helm/bitnami/wordpress/15.0.11) | [GPLv2](https://mariadb.com/kb/en/library/mariadb-license/) |
 
 ## Getting Started
 

--- a/stacks/wordpress/README.md
+++ b/stacks/wordpress/README.md
@@ -13,8 +13,8 @@ This DigitalOcean Marketplace Kubernetes 1-Click installs [WordPress](https://gi
 
 | Package               | Application Version   | Helm Chart Version |License                                                                                    |
 | ---| ---- | ---- | ------------- |
-| WordPress | 5.9.1 | [13.0.22](https://artifacthub.io/packages/helm/bitnami/wordpress/13.0.22) | [GPLv2](https://wordpress.org/about/license/) |
-| MariaDB | 10.5.15 | [13.0.22](https://artifacthub.io/packages/helm/bitnami/wordpress/13.0.22) | [GPLv2](https://mariadb.com/kb/en/library/mariadb-license/) |
+| WordPress | 6.0.1 | [15.0.11](https://artifacthub.io/packages/helm/bitnami/wordpress/15.0.11) | [GPLv2](https://wordpress.org/about/license/) |
+| MariaDB | 10.6.8 | [15.0.11](https://artifacthub.io/packages/helm/bitnami/wordpress/1.0.22) | [GPLv2](https://mariadb.com/kb/en/library/mariadb-license/) |
 
 ## Getting Started
 
@@ -40,7 +40,7 @@ The output looks similar to (notice that the `STATUS` column value is `deployed`
 
 ```text
 NAME      NAMESPACE REVISION UPDATED                              STATUS   CHART             APP VERSION
-wordpress wordpress 1        2022-03-10 14:56:39.419223 +0200 EET deployed wordpress-13.0.22 5.9.1
+wordpress wordpress 1        2022-03-10 14:56:39.419223 +0200 EET deployed wordpress-15.0.11 6.0.1
 ```
 
 Next, verify if the WordPress and MariaDB Pods are up and running:
@@ -109,13 +109,13 @@ The WordPress stack provides some custom values to start with. Please have a loo
 You can always inspect all the available options, as well as the default values for the WordPress Helm chart by running below command:
 
 ```console
-helm show values bitnami/wordpress --version 13.0.22
+helm show values bitnami/wordpress --version 15.0.11
 ```
 
 After tweaking the Helm values file (`values.yml`) according to your needs, you can always apply the changes via `helm upgrade` command, as shown below:
 
 ```console
-helm upgrade wordpress bitnami/wordpress --version 13.0.22\
+helm upgrade wordpress bitnami/wordpress --version 15.0.11 \
   --namespace wordpress \
   --values values.yml
 ```
@@ -137,7 +137,7 @@ See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command document
 
 ### Uninstalling
 
-To uninstall WordPress, you'll need to have Helm 3 installed. Once install, run the following:
+To uninstall WordPress, you'll need to have Helm 3 installed. Once installed, run the following:
 
 ```bash
 helm uninstall wordpress -n wordpress


### PR DESCRIPTION
## BACKGROUND
We have updated the versions of apps we use in the Starter Kit here https://github.com/digitalocean/Kubernetes-Starter-Kit-Developers and we are updating their 1-click counterparts.

## Changes
Upgraded and tested both via fresh install of new version as well as upgrading of:
- ambassador
- ingress-nginx
- cert-manager
- argo-cd
- k-native
- kube-prometheus-stack
- loki
- wordpress

-----------------------------------------------------------------------

## Checklist
- [x] review the [contributing doc](https://github.com/digitalocean/marketplace-kubernetes/blob/master/CONTRIBUTING.md) with steps for both adding or updating your application (if applicable)
------------------------------------------------------------------------

Reviewer: @marketplace-eng
