### PR TITLE
Update 1Password/op-scim-bridge to v2.5.1

### DIFF
--- a/stacks/op-scim-bridge/deploy.sh
+++ b/stacks/op-scim-bridge/deploy.sh
@@ -9,7 +9,7 @@ helm repo add "$REPO_NAME" "$REPO_URL"
 helm repo update > /dev/null
 
 CHART_NAME="op-scim-bridge"
-CHART_VERSION="2.6.0"
+CHART_VERSION="2.7.0"
 
 RELEASE="op-scim-bridge"
 NAMESPACE="op-scim-bridge"


### PR DESCRIPTION
## BACKGROUND
* In this release we are updating the 1Password SCIM bridge to v2.5.1.

-----------------------------------------------------------------------

## Changes
* Chart includes [1Password SCIM bridge v2.5.1](https://app-updates.agilebits.com/product_history/SCIM#v205011)

-----------------------------------------------------------------------

## Checklist
- [X] review the [contributing doc](https://github.com/digitalocean/marketplace-kubernetes/blob/master/CONTRIBUTING.md) with steps for both adding or updating your application (if applicable)
------------------------------------------------------------------------

Reviewer: @marketplace-eng
