### PR TITLE
Upgrades version of kube state metrics

### DIFF
--- a/stacks/kube-state-metrics/deploy.sh
+++ b/stacks/kube-state-metrics/deploy.sh
@@ -13,7 +13,7 @@ helm repo update > /dev/null
 ################################################################################
 STACK="kube-state-metrics"
 CHART="bitnami/kube-state-metrics"
-CHART_VERSION="2.1.13"
+CHART_VERSION="2.2.0"
 NAMESPACE="kube-system"
 
 if [ -z "${MP_KUBERNETES}" ]; then


### PR DESCRIPTION
## BACKGROUND
A customer reported that kube state metrics cannot be installed from the marketplace here:
[MP-5411](https://jira.internal.digitalocean.com/browse/MP-5411).
Reproduced the issue locally and errored out with: `Error: failed to download "bitnami/kube-state-metrics" at version "2.1.3"`
Ran `helm search repo bitnami/kube-state-metrics --versions` and it appears that version 2.1.3 is not included anymore. 

-----------------------------------------------------------------------

## Changes
Upgraded the version to 2.2.0.

-----------------------------------------------------------------------

## Checklist
- [x] review the [contributing doc](https://github.com/digitalocean/marketplace-kubernetes/blob/master/CONTRIBUTING.md) with steps for both adding or updating your application (if applicable)
------------------------------------------------------------------------

Reviewer: @marketplace-eng
