### PR TITLE
memphis upgrade to 0.3.5

### DIFF
--- a/stacks/memphis/deploy.sh
+++ b/stacks/memphis/deploy.sh
@@ -13,7 +13,7 @@ helm repo update > /dev/null
 ################################################################################
 STACK="memphis"
 CHART="memphis/memphis"
-CHART_VERSION="0.3.0"
+CHART_VERSION="0.3.5"
 NAMESPACE="memphis"
 
 values="https://raw.githubusercontent.com/memphisdev/memphis-k8s/gh-pages/memphis/values.yaml"

--- a/stacks/memphis/values.yml
+++ b/stacks/memphis/values.yml
@@ -1,9 +1,9 @@
 rootPwd: ""
 connectionToken: ""
-analytics: true
 dashboard:
   port: 80
 image: ""
+analytics: true
 logsRetentionInDays: 3
 teston: ""
 #####################################
@@ -14,7 +14,7 @@ teston: ""
 nats:
   #image: nats:2.7.2-alpine
   image: memphisos/memphis-nats:2.8.4-alpine3.15
-  pullPolicy: IfNotPresent
+  pullPolicy: Always 
 
   # The servers name prefix, must be used for example when we want a NATS cluster
   # spanning multiple Kubernetes clusters.
@@ -111,7 +111,7 @@ nats:
   resources: {}
 
   client:
-    port: 7766
+    port: 6666
     portName: "client"
 
   # Server settings.
@@ -129,13 +129,15 @@ nats:
     # to a client that has no activity.
     pingInterval:
 
-    # NOTE: this should be at least the same as 'terminationGracePeriodSeconds'
-    lameDuckDuration: "120s"
+    # grace period after pod begins shutdown before starting to close client connections
+    lameDuckGracePeriod: "10s"
 
-  # terminationGracePeriodSeconds determines how long to allow for a pod
-  # to be restarted.
-  terminationGracePeriodSeconds: 120
+    # duration over which to slowly close close client connections after lameDuckGracePeriod has passed
+    lameDuckDuration: "30s"
 
+  # terminationGracePeriodSeconds determines how long to wait for graceful shutdown
+  # this should be at least `lameDuckGracePeriod` + `lameDuckDuration` + 20s shutdown overhead
+  terminationGracePeriodSeconds: 60
   logging:
     debug:
     trace:
@@ -438,7 +440,7 @@ gateway:
 # enabled, an initializer container will be used to gather
 # the public ips.
 bootconfig:
-  image: memphisos/memphis-broker-boot-config:0.5.4
+  image: memphisos/memphis-broker-boot-config-staging:0.5.4
   pullPolicy: IfNotPresent
   securityContext: {}
 
@@ -492,7 +494,7 @@ natsbox:
   #    operator: "Equal|Exists"
   #    value: "value"
   #    effect: "NoSchedule|PreferNoSchedule|NoExecute(1.6 only)"
-  
+
   # Additional nats-box server Volume mounts
   extraVolumeMounts: []
 
@@ -502,7 +504,7 @@ natsbox:
 # The NATS config reloader image to use.
 reloader:
   enabled: true
-  image: memphisos/memphis-broker-server-config-reloader:0.6.2
+  image: memphisos/memphis-config-reloader:latest
   pullPolicy: IfNotPresent
   securityContext: {}
   extraConfigs: []


### PR DESCRIPTION
## BACKGROUND
* Add information about the background and reason for the change.
Memphis version release
-----------------------------------------------------------------------

## Changes
* List the changes that you made

- When opening Memphis UI for the first time, users will be able to create their first management user directly
- Client connections (SDKs) no longer have to send 3 different ports (dataPort, tcpPort, managementPort) in order to connect with Memphis, now all you to do is to send 1 port, which defaults to 6666
- Python SDK
- New version of Node.js SDK (0.4.0) which includes NestJS support
- New version of Go SDK (0.1.3)
- General improvements

-----------------------------------------------------------------------

## Checklist
- [X ] review the [contributing doc](https://github.com/digitalocean/marketplace-kubernetes/blob/master/CONTRIBUTING.md) with steps for both adding or updating your application (if applicable)
------------------------------------------------------------------------

Reviewer: @marketplace-eng
