### PR TITLE
Release version bump to helm chart 2.8.0

### DIFF
--- a/stacks/op-scim-bridge/deploy.sh
+++ b/stacks/op-scim-bridge/deploy.sh
@@ -9,7 +9,7 @@ helm repo add "$REPO_NAME" "$REPO_URL"
 helm repo update > /dev/null
 
 CHART_NAME="op-scim-bridge"
-CHART_VERSION="2.7.1"
+CHART_VERSION="2.8.0"
 
 RELEASE="op-scim-bridge"
 NAMESPACE="op-scim-bridge"


### PR DESCRIPTION
## BACKGROUND
* Version bump the 1Password SCIM bridge to version `2.6.2` (helm chart version `2.8.0`)

-----------------------------------------------------------------------

## Changes
* Version bump to helm chart 2.8.0

-----------------------------------------------------------------------

## Checklist
- [X] review the [contributing doc](https://github.com/digitalocean/marketplace-kubernetes/blob/master/CONTRIBUTING.md) with steps for both adding or updating your application (if applicable)
------------------------------------------------------------------------

Reviewer: @marketplace-eng
