### PR TITLE
Fix path issues for search-values.yaml

### DIFF
--- a/stacks/fusionauth/README.md
+++ b/stacks/fusionauth/README.md
@@ -6,7 +6,7 @@ FusionAuth is a modern platform for Customer Identity and Access Management (CIA
 
 | Package       | Application Version | License                                                       |
 |---------------|---------------------|---------------------------------------------------------------|
-| FusionAuth    | 1.40.2              | [License](https://fusionauth.io/license)                      |
+| FusionAuth    | 1.42.0              | [License](https://fusionauth.io/license)                      |
 
 ### Resources
 This stack was successfully tested with a Digital Ocean Kubernetes Cluster with 6 GB RAM and 4 vCPUs.

--- a/stacks/fusionauth/deploy.sh
+++ b/stacks/fusionauth/deploy.sh
@@ -22,10 +22,12 @@ DB_FUSIONAUTH_USER_PASSWORD=`cat /dev/urandom | tr -dc '[:alnum:]' | head -c 42`
 if [ -z "${MP_KUBERNETES}" ]; then
   # use local version of values.yml
   ROOT_DIR=$(git rev-parse --show-toplevel)
-  values="$ROOT_DIR/stacks/fusionauth/values.yml"
+  VALUES="$ROOT_DIR/stacks/fusionauth/values.yml"
+  SEARCH_VALUES="$ROOT_DIR/stacks/fusionauth/search-values.yaml"
 else
   # use github hosted master version of values.yml
-  values="https://raw.githubusercontent.com/digitalocean/marketplace-kubernetes/master/stacks/fusionauth/values.yml"
+  VALUES="https://raw.githubusercontent.com/digitalocean/marketplace-kubernetes/master/stacks/fusionauth/values.yml"
+  SEARCH_VALUES="https://raw.githubusercontent.com/digitalocean/marketplace-kubernetes/master/stacks/fusionauth/search-values.yaml"
 fi
 
 # Add repos and update
@@ -36,7 +38,7 @@ helm repo update > /dev/null
 
 # Install PostgresSQL and Elasticsearch
 helm install db bitnami/postgresql --create-namespace --namespace "$NAMESPACE" --set auth.enablePostgresUser=true --set auth.postgresPassword="$DB_POSTGRES_USER_PASSWORD" --set image.tag=14.6.0-debian-11-r11
-helm install search bitnami/elasticsearch --namespace "$NAMESPACE" -f search-values.yaml
+helm install search bitnami/elasticsearch --namespace "$NAMESPACE" -f "$SEARCH_VALUES"
 
 
 helm upgrade "$STACK" "$CHART" \
@@ -44,7 +46,7 @@ helm upgrade "$STACK" "$CHART" \
   --install \
   --timeout 8m0s \
   --namespace "$NAMESPACE" \
-  --values "$values" \
+  --values "$VALUES" \
   --version "$CHART_VERSION" \
   --set database.password="$DB_FUSIONAUTH_USER_PASSWORD" \
   --set database.root.password="$DB_POSTGRES_USER_PASSWORD"

--- a/stacks/fusionauth/upgrade.sh
+++ b/stacks/fusionauth/upgrade.sh
@@ -21,10 +21,10 @@ NAMESPACE="fusionauth"
 if [ -z "${MP_KUBERNETES}" ]; then
   # use local version of values.yml
   ROOT_DIR=$(git rev-parse --show-toplevel)
-  values="$ROOT_DIR/stacks/fusionauth/values.yml"
+  VALUES="$ROOT_DIR/stacks/fusionauth/values.yml"
 else
   # use github hosted master version of values.yml
-  values="https://raw.githubusercontent.com/digitalocean/marketplace-kubernetes/master/stacks/fusionauth/values.yml"
+  VALUES="https://raw.githubusercontent.com/digitalocean/marketplace-kubernetes/master/stacks/fusionauth/values.yml"
 fi
 
 # Retrieve current passwords and set them again during upgrade.
@@ -33,6 +33,6 @@ DB_POSTGRES_USER_PASSWORD=$(kubectl -n $NAMESPACE get secrets fusionauth-credent
 
 helm upgrade "$STACK" "$CHART" \
 --namespace "$NAMESPACE" \
---values "$values" \
+--values "$VALUES" \
 --set database.password="$DB_FUSIONAUTH_USER_PASSWORD" \
 --set database.root.password="$DB_POSTGRES_USER_PASSWORD"


### PR DESCRIPTION
## BACKGROUND
* Previous code required deployment from the `stacks/fusionauth` directory, while marketplace deployments execute from the repo root.

Note: Tested on ubuntu 22.04. Does not work directly from MacOS due to `tr` incompatibility.

-----------------------------------------------------------------------

## Changes
* During marketplace deployment, use ES search-values.yaml from the github master URL.

-----------------------------------------------------------------------

## Checklist
- [x] review the [contributing doc](https://github.com/digitalocean/marketplace-kubernetes/blob/master/CONTRIBUTING.md) with steps for both adding or updating your application (if applicable)
------------------------------------------------------------------------

Reviewer: @marketplace-eng
