### PR TITLE
Bump versions of VictoriaMetrics Cluster, vmagent, operator to the latest versions

### DIFF
--- a/stacks/victoria-metrics-cluster/README.md
+++ b/stacks/victoria-metrics-cluster/README.md
@@ -34,9 +34,9 @@ across nodes to ensure availability.
 
 | Package  | Version | License |
 | ------------- | ------------- | ------------- |
-| VictoriaMetrics Cluster  | [1.80.0](https://docs.victoriametrics.com/CHANGELOG.html#v1800)  | Apache 2.0  |
-| vmagent  | [1.80.0](https://docs.victoriametrics.com/CHANGELOG.html#v1800)  | Apache 2.0  |
-| vmoperator  | [0.27.2](https://github.com/VictoriaMetrics/operator/releases/tag/v0.27.2)  | Apache 2.0  |
+| VictoriaMetrics Cluster  | [1.87.1](https://docs.victoriametrics.com/CHANGELOG.html#v1871)  | Apache 2.0  |
+| vmagent  | [1.87.1](https://docs.victoriametrics.com/CHANGELOG.html#v1871)  | Apache 2.0  |
+| vmoperator  | [0.30.4](https://github.com/VictoriaMetrics/operator/releases/tag/v0.30.4)  | Apache 2.0  |
 
 ## Getting started after deploying VictoriaMetrics Cluster
 

--- a/stacks/victoria-metrics-cluster/yaml/vmagent.yaml
+++ b/stacks/victoria-metrics-cluster/yaml/vmagent.yaml
@@ -7,6 +7,6 @@ spec:
   replicaCount: 1
   image:
     repository: victoriametrics/vmagent
-    tag: v1.80.0
+    tag: v1.87.1
   remoteWrite:
-    - url: "http://vminsert-vmcluster.default.svc.cluster.local:8480/insert/0/prometheus/api/v1/write"
+    - url: "http://vminsert-vmcluster.default.svc.cluster.local:8480/insert/0/prometheus/"

--- a/stacks/victoria-metrics-cluster/yaml/vmcluster.yaml
+++ b/stacks/victoria-metrics-cluster/yaml/vmcluster.yaml
@@ -8,14 +8,14 @@ spec:
       replicaCount: 2
       image:
         repository: victoriametrics/vmstorage
-        tag: v1.80.0-cluster
+        tag: v1.87.1-cluster
   vmselect:
       replicaCount: 2
       image:
         repository: victoriametrics/vmselect
-        tag: v1.80.0-cluster
+        tag: v1.87.1-cluster
   vminsert:
       replicaCount: 2
       image:
         repository: victoriametrics/vminsert
-        tag: v1.80.0-cluster
+        tag: v1.87.1-cluster


### PR DESCRIPTION
## BACKGROUND

* Product version update

-----------------------------------------------------------------------

## Changes
* README.md: update version of VictoriaMetrics Cluster, vmagent, operator to the latest versions
* bump [vmagent](https://docs.victoriametrics.com/vmagent.html) version to the latest [v1.87.1](https://docs.victoriametrics.com/CHANGELOG.html#v1871)
* bump version of [VictoriaMetrics Cluster](https://docs.victoriametrics.com/Cluster-VictoriaMetrics.html) to the latest [v1.87.1](https://docs.victoriametrics.com/CHANGELOG.html#v1871)
* bump VictoriaMetrics [operator](https://github.com/VictoriaMetrics/operator) version to the latest [v0.30.4](https://github.com/VictoriaMetrics/operator/releases/tag/v0.30.4)

-----------------------------------------------------------------------

## Checklist
- [x] review the [contributing doc](https://github.com/digitalocean/marketplace-kubernetes/blob/master/CONTRIBUTING.md) with steps for both adding or updating your application (if applicable)
------------------------------------------------------------------------

Reviewer: @marketplace-eng
