### PR TITLE
Update Chart version for SCIM bridge version 2.7.4

### DIFF
--- a/stacks/op-scim-bridge/deploy.sh
+++ b/stacks/op-scim-bridge/deploy.sh
@@ -9,7 +9,7 @@ helm repo add "$REPO_NAME" "$REPO_URL"
 helm repo update > /dev/null
 
 CHART_NAME="op-scim-bridge"
-CHART_VERSION="2.9.1"
+CHART_VERSION="2.9.4"
 
 RELEASE="op-scim-bridge"
 NAMESPACE="op-scim-bridge"


### PR DESCRIPTION
## BACKGROUND
* Updates the Chart Version for the `op-scim-bridge` project.

-----------------------------------------------------------------------

## Changes
* Update Chart Version to 2.9.4, the latest version in [1password/op-scim-helm](https://github.com/1Password/op-scim-helm/releases).

-----------------------------------------------------------------------

## Checklist
- [X] review the [contributing doc](https://github.com/digitalocean/marketplace-kubernetes/blob/master/CONTRIBUTING.md) with steps for both adding or updating your application (if applicable)
------------------------------------------------------------------------

Reviewer: @marketplace-eng
