### PR TITLE
Fix linkerd app

### DIFF
--- a/stacks/linkerd2/deploy.sh
+++ b/stacks/linkerd2/deploy.sh
@@ -27,8 +27,6 @@ $BINARY install --crds --ignore-cluster | kubectl apply -f -
 $BINARY install --ignore-cluster | kubectl apply -f -
 
 # ensure services are running
-kubectl get deployments -o custom-columns=NAME:.metadata.name
-
 kubectl get deployments -o custom-columns=NAME:.metadata.name | tail -n +2 | while read -r line
 do
   if [ ! -z "$line" ]

--- a/stacks/linkerd2/deploy.sh
+++ b/stacks/linkerd2/deploy.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-LINKERD2_VERSION="stable-2.11.4"
+LINKERD2_VERSION="stable-2.12.4"
 TMP_DIR=$(mktemp -d)
 
 # determine OS
@@ -23,12 +23,20 @@ wget -q $URL -O "$BINARY" && chmod +x "$BINARY"
 kubectl config set-context --current --namespace=linkerd
 
 # deploy linkerd
+$BINARY install --crds --ignore-cluster | kubectl apply -f -
 $BINARY install --ignore-cluster | kubectl apply -f -
 
 # ensure services are running
+kubectl get deployments -o custom-columns=NAME:.metadata.name
+
 kubectl get deployments -o custom-columns=NAME:.metadata.name | tail -n +2 | while read -r line
 do
-  kubectl rollout status -w deployment/"$line"
+  if [ ! -z "$line" ]
+  then 
+    kubectl rollout status -w deployment/"$line"
+  else
+    break
+  fi
 done
 
 # install the viz extension

--- a/stacks/linkerd2/uninstall.sh
+++ b/stacks/linkerd2/uninstall.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-LINKERD2_VERSION="stable-2.11.4"
+LINKERD2_VERSION="stable-2.12.4"
 TMP_DIR=$(mktemp -d)
 
 # determine OS

--- a/stacks/linkerd2/upgrade.sh
+++ b/stacks/linkerd2/upgrade.sh
@@ -36,6 +36,8 @@ do
   if [ ! -z "$line" ]
   then 
     kubectl rollout status -w deployment/"$line"
+  else
+    break
   fi
 done
 

--- a/stacks/linkerd2/upgrade.sh
+++ b/stacks/linkerd2/upgrade.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-LINKERD2_VERSION="stable-2.11.4"
+LINKERD2_VERSION="stable-2.12.4"
 TMP_DIR=$(mktemp -d)
 
 # determine OS
@@ -33,7 +33,10 @@ $BINARY upgrade | kubectl apply --prune -l linkerd.io/control-plane-ns=linkerd \
 # ensure services are running
 kubectl get deployments -o custom-columns=NAME:.metadata.name | tail -n +2 | while read -r line
 do
-  kubectl rollout status -w deployment/"$line"
+  if [ ! -z "$line" ]
+  then 
+    kubectl rollout status -w deployment/"$line"
+  fi
 done
 
 # upgrade the viz extension


### PR DESCRIPTION
## BACKGROUND
* Linkerd deploy file is outdated and the app can't be installed

-----------------------------------------------------------------------

## Changes
* Update linkerd version from 2.11.2 to 2.12.4
* Add required linkerd crds installation
* Add dirty fix for failing kubectl rollout command

-----------------------------------------------------------------------

## Checklist
- [X] review the [contributing doc](https://github.com/digitalocean/marketplace-kubernetes/blob/master/CONTRIBUTING.md) with steps for both adding or updating your application (if applicable)
------------------------------------------------------------------------

Reviewer: @marketplace-eng
