### PR TITLE
Bump Netdata Helm Chart to version 3.7.47 (Agent v1.38.1)

### DIFF
--- a/stacks/netdata/deploy.sh
+++ b/stacks/netdata/deploy.sh
@@ -13,7 +13,7 @@ helm repo update > /dev/null
 ################################################################################
 STACK="netdata"
 CHART="netdata/netdata"
-CHART_VERSION="3.7.29"
+CHART_VERSION="3.7.47"
 NAMESPACE="netdata"
 
 if [ -z "${MP_KUBERNETES}" ]; then


### PR DESCRIPTION
## BACKGROUND

Keeps Netdata up to date.

-----------------------------------------------------------------------

## Changes
* Update Netdata Agent to version 1.38.1
* Assorted other fixes to the Helm chart itself.

-----------------------------------------------------------------------

## Checklist
- [x] review the [contributing doc](https://github.com/digitalocean/marketplace-kubernetes/blob/master/CONTRIBUTING.md) with steps for both adding or updating your application (if applicable)
------------------------------------------------------------------------

Reviewer: @marketplace-eng