### PR TITLE
Upgrade loki stack to 2.9.9

### DIFF
--- a/stacks/loki/deploy.sh
+++ b/stacks/loki/deploy.sh
@@ -13,7 +13,7 @@ helm repo update > /dev/null
 ################################################################################
 STACK="loki"
 CHART="grafana/loki-stack"
-CHART_VERSION="2.6.3"
+CHART_VERSION="2.9.9"
 NAMESPACE="loki-stack"
 
 if [ -z "${MP_KUBERNETES}" ]; then


### PR DESCRIPTION
## BACKGROUND
* Grafana Loki is suspended cause of installation issues, this PR fixes the issue.

-----------------------------------------------------------------------

## Changes
* Update helm stack version from 2.6.3 to 2.9.9

-----------------------------------------------------------------------

## Checklist
- [X] review the [contributing doc](https://github.com/digitalocean/marketplace-kubernetes/blob/master/CONTRIBUTING.md) with steps for both adding or updating your application (if applicable)
------------------------------------------------------------------------

Reviewer: @marketplace-eng
