### PR TITLE
update version of cert-manager (1.8 -> 1.11)

### DIFF
--- a/stacks/cert-manager/README.md
+++ b/stacks/cert-manager/README.md
@@ -18,9 +18,9 @@ The following diagram shows how Cert-Manager works in conjunction with the Nginx
 
 ## Software Included
 
-| Package | Cert-Manager Version | Helm Chart Version | License |
-|---------|----------------------|--------------------|---------|
-| Cert-Manager | [1.8.0](https://github.com/cert-manager/cert-manager/releases/tag/v1.8.0) | [1.8.0](https://artifacthub.io/packages/helm/cert-manager/cert-manager/1.8.0) | [Apache 2.0](https://github.com/cert-manager/cert-manager/blob/master/LICENSE) |
+| Package | Cert-Manager Version                                                        | Helm Chart Version                                                              | License |
+|---------|-----------------------------------------------------------------------------|---------------------------------------------------------------------------------|---------|
+| Cert-Manager | [1.11.0](https://github.com/cert-manager/cert-manager/releases/tag/v1.11.0) | [1.11.0](https://artifacthub.io/packages/helm/cert-manager/cert-manager/1.11.0) | [Apache 2.0](https://github.com/cert-manager/cert-manager/blob/master/LICENSE) |
 
 ## Getting Started
 
@@ -45,7 +45,7 @@ If the installation was successful, the `STATUS` column value in the output read
 
 ```text
 NAME            NAMESPACE       REVISION        UPDATED                                 STATUS          CHART                   APP VERSION
-cert-manager    cert-manager    1               2022-02-21 18:49:08.264191 +0200 EET    deployed        cert-manager-v1.8.0     v1.8.0
+cert-manager    cert-manager    1               2023-04-20 07:51:00.307798 +0200 EET    deployed        cert-manager-v1.11.0     v1.11.0
 ```
 
 Next, verify that the Cert-Manager pods are up and running with the following command:
@@ -70,13 +70,13 @@ The `cert-manager` has custom default Helm values. See the [values](./values.yml
 To inspect its current values, run the following command:
 
 ```console
-helm show values jetstack/cert-manager --version 1.8.0
+helm show values jetstack/cert-manager --version 1.11.0
 ```
 
 To change these values, open the Helm values file `values.yml`, change whatever values you want, save and exit the file, and apply the changes by running `helm upgrade` command:
 
 ```console
-helm upgrade cert-manager jetstack/cert-manager --version 1.8.0 \
+helm upgrade cert-manager jetstack/cert-manager --version 1.11.0 \
   --namespace cert-manager \
   --values values.yml
 ```

--- a/stacks/cert-manager/deploy.sh
+++ b/stacks/cert-manager/deploy.sh
@@ -13,7 +13,7 @@ helm repo update > /dev/null
 ################################################################################
 STACK="cert-manager"
 CHART="jetstack/cert-manager"
-CHART_VERSION="1.8.0"
+CHART_VERSION="1.11.0"
 NAMESPACE="cert-manager"
 
 if [ -z "${MP_KUBERNETES}" ]; then

--- a/stacks/cert-manager/values.yml
+++ b/stacks/cert-manager/values.yml
@@ -1,5 +1,5 @@
 ## Chart: jetstack/cert-manager
-## Ref: https://github.com/cert-manager/cert-manager/blob/v1.8.0/deploy/charts/cert-manager/
+## Ref: https://github.com/cert-manager/cert-manager/blob/v1.11.0/deploy/charts/cert-manager/
 ##
 
 # Cert-Manager requires a number of CRD resources to be installed beforehand


### PR DESCRIPTION
## BACKGROUND
Cert-Manager version for 1-click install being version 1.8, this version is now EOL currently supported versions are 1.10, 1.11
-----------------------------------------------------------------------

## Changes
* Cert-Manager version (1.8 -> 1.11)

-----------------------------------------------------------------------

## Checklist
- [ ] review the [contributing doc](https://github.com/digitalocean/marketplace-kubernetes/blob/master/CONTRIBUTING.md) with steps for both adding or updating your application (if applicable)
------------------------------------------------------------------------

Reviewer: @marketplace-eng
