### PR TITLE
Bump Netdata Helm Chart version to 3.7.54.

### DIFF
--- a/stacks/netdata/deploy.sh
+++ b/stacks/netdata/deploy.sh
@@ -13,7 +13,7 @@ helm repo update > /dev/null
 ################################################################################
 STACK="netdata"
 CHART="netdata/netdata"
-CHART_VERSION="3.7.51"
+CHART_VERSION="3.7.54"
 NAMESPACE="netdata"
 
 if [ -z "${MP_KUBERNETES}" ]; then


### PR DESCRIPTION
Corresponds to Netdata agent version 1.39.0, plus a few other fixes in the chart itself.

## BACKGROUND

Keeps Netdata up to date.

-----------------------------------------------------------------------

## Changes

- Update Netdata Agent to v1.39.0
- Assorted other fixes to the chart itself.

-----------------------------------------------------------------------

## Checklist
- [x] review the [contributing doc](https://github.com/digitalocean/marketplace-kubernetes/blob/master/CONTRIBUTING.md) with steps for both adding or updating your application (if applicable)
------------------------------------------------------------------------

Reviewer: @marketplace-eng
