### PR TITLE
Update webadc and paralus to last versions

### DIFF
--- a/stacks/ls-k8s-webadc/deploy.sh
+++ b/stacks/ls-k8s-webadc/deploy.sh
@@ -13,7 +13,7 @@ helm repo update > /dev/null
 ################################################################################
 STACK="ls-k8s-webadc"
 CHART="ls-k8s-webadc/ls-k8s-webadc"
-CHART_VERSION="0.2.3"
+CHART_VERSION="0.2.4"
 NAMESPACE="ls-k8s-webadc"
 
 kubectl get secret ls-k8s-webadc -n ls-k8s-webadc > /dev/null 2>&1
@@ -50,4 +50,4 @@ helm upgrade "$STACK" "$CHART" \
   --install \
   --namespace "$NAMESPACE" \
   --values "$values" \
-  --version "$CHART_VERSION" \
+  --version "$CHART_VERSION"

--- a/stacks/paralus/deploy.sh
+++ b/stacks/paralus/deploy.sh
@@ -14,7 +14,7 @@ helm repo update > /dev/null
 ################################################################################
 STACK="paralus"
 CHART="paralus/ztka"
-CHART_VERSION="0.1.7"
+CHART_VERSION="0.2.4"
 NAMESPACE="paralus"
 
 if [ -z "${MP_KUBERNETES}" ]; then


### PR DESCRIPTION
## BACKGROUND
* Our team found that 3 apps from the catalog don't install: ls-k8-webadc, paralus and posthog. After investigation we fixed two of them and suspended posthog

-----------------------------------------------------------------------

## Changes
* Update ls-k8-webadc chart version to 0.2.4
* Update paralus chart version to 0.2.4

-----------------------------------------------------------------------

## Checklist
- [X] review the [contributing doc](https://github.com/digitalocean/marketplace-kubernetes/blob/master/CONTRIBUTING.md) with steps for both adding or updating your application (if applicable)
------------------------------------------------------------------------

Reviewer: @marketplace-eng
