### PR TITLE
Bump Netdata chart version to 3.7.62

### DIFF
--- a/stacks/netdata/deploy.sh
+++ b/stacks/netdata/deploy.sh
@@ -13,7 +13,7 @@ helm repo update > /dev/null
 ################################################################################
 STACK="netdata"
 CHART="netdata/netdata"
-CHART_VERSION="3.7.54"
+CHART_VERSION="3.7.62"
 NAMESPACE="netdata"
 
 if [ -z "${MP_KUBERNETES}" ]; then


### PR DESCRIPTION
Corresponds to agent version 1.40.1, plus an assortment of fixes and changes in the chart itself.

## BACKGROUND

Keeps Netdata up to date.

-----------------------------------------------------------------------

## Changes

- Update Netdata Agent to v1.40.1
- Assorted other fixes to the chart itself.

-----------------------------------------------------------------------

## Checklist
- [x] review the [contributing doc](https://github.com/digitalocean/marketplace-kubernetes/blob/master/CONTRIBUTING.md) with steps for both adding or updating your application (if applicable)
------------------------------------------------------------------------

Reviewer: @marketplace-eng
