### PR TITLE
Remove jq from gopaddie deploy script

### DIFF
--- a/stacks/gopaddle-lite/deploy.sh
+++ b/stacks/gopaddle-lite/deploy.sh
@@ -33,11 +33,11 @@ kubectl apply -f "$clusterrole"
 kubectl apply -f "$clusterrolebinding"
 
 # Get the first node's external IP, if it exists
-FIRST_NODE_EXT_IP=$(kubectl get nodes -o json | jq -r '.items[0].status.addresses[] | select(.type=="ExternalIP") | .address' 2>/dev/null)
+FIRST_NODE_EXT_IP=$(kubectl get nodes -o jsonpath='{$.items[0].status.addresses[?(@.type=="ExternalIP")].address}' 2>/dev/null)
 
 # If there's no external IP, get the internal IP
 if [ -z "$FIRST_NODE_EXT_IP" ]; then
-        FIRST_NODE_IP=$(kubectl get nodes -o json | jq -r '.items[0].status.addresses[] | select(.type=="InternalIP") | .address')
+        FIRST_NODE_IP=$(kubectl get nodes -o jsonpath='{$.items[0].status.addresses[?(@.type=="InternalIP")].address}' 2>/dev/null)
 else
         FIRST_NODE_IP="$FIRST_NODE_EXT_IP"
 fi

--- a/stacks/gopaddle-lite/upgrade.sh
+++ b/stacks/gopaddle-lite/upgrade.sh
@@ -27,11 +27,11 @@ else
 fi
 
 # Get the first node's external IP, if it exists
-FIRST_NODE_EXT_IP=$(kubectl get nodes -o json | jq -r '.items[0].status.addresses[] | select(.type=="ExternalIP") | .address' 2>/dev/null)
+FIRST_NODE_EXT_IP=$(kubectl get nodes -o jsonpath='{$.items[0].status.addresses[?(@.type=="ExternalIP")].address}' 2>/dev/null)
 
 # If there's no external IP, get the internal IP
 if [ -z "$FIRST_NODE_EXT_IP" ]; then
-        FIRST_NODE_IP=$(kubectl get nodes -o json | jq -r '.items[0].status.addresses[] | select(.type=="InternalIP") | .address')
+        FIRST_NODE_IP=$(kubectl get nodes -o jsonpath='{$.items[0].status.addresses[?(@.type=="InternalIP")].address}' 2>/dev/null)
 else
         FIRST_NODE_IP="$FIRST_NODE_EXT_IP"
 fi


### PR DESCRIPTION
## BACKGROUND
* Add information about the background and reason for the change.
Addon-service runs on apline system where jq is not installed by default

## Changes
* List the changes that you made
* Remove using of `jq` in gopaddle deploy.sh
* Remove using of `jq` in gopaddle upgrade.sh
-----------------------------------------------------------------------

## Checklist
- [X] review the [contributing doc](https://github.com/digitalocean/marketplace-kubernetes/blob/master/CONTRIBUTING.md) with steps for both adding or updating your application (if applicable)
------------------------------------------------------------------------

Reviewer: @marketplace-eng
