### PR TITLE
update otomi and ls-k8s-webadc versions

### DIFF
--- a/stacks/ls-k8s-webadc/deploy.sh
+++ b/stacks/ls-k8s-webadc/deploy.sh
@@ -13,7 +13,7 @@ helm repo update > /dev/null
 ################################################################################
 STACK="ls-k8s-webadc"
 CHART="ls-k8s-webadc/ls-k8s-webadc"
-CHART_VERSION="0.2.4"
+CHART_VERSION="0.2.5"
 NAMESPACE="ls-k8s-webadc"
 
 kubectl get secret ls-k8s-webadc -n ls-k8s-webadc > /dev/null 2>&1

--- a/stacks/otomi/deploy.sh
+++ b/stacks/otomi/deploy.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-set -eu
+set -e
 
 ################################################################################
 # repo
@@ -14,6 +14,7 @@ helm repo update > /dev/null
 STACK="otomi"
 CHART="otomi/otomi"
 NAMESPACE="default"
+VERSION="1.24"
 
 if [ -z "${MP_KUBERNETES}" ]; then
   # use local version of values.yml
@@ -29,4 +30,5 @@ helm upgrade "$STACK" "$CHART" \
   --install \
   --timeout 8m0s \
   --namespace "$NAMESPACE" \
+  --set cluster.k8sVersion="$VERSION" \
   --values "$values" 


### PR DESCRIPTION
## BACKGROUND
Otomi and ls-k8s-webadc are not installing correctly

-----------------------------------------------------------------------

## Changes
* Bumped ls-k8s-webadc helm chart version to 0.2.5
* Set K8s version for Otomi to the most recent supported by the app (1.24)


Reviewer: @marketplace-eng
