### PR TITLE
Version bump to 2.8.2

### DIFF
--- a/stacks/op-scim-bridge/deploy.sh
+++ b/stacks/op-scim-bridge/deploy.sh
@@ -9,7 +9,7 @@ helm repo add "$REPO_NAME" "$REPO_URL"
 helm repo update > /dev/null
 
 CHART_NAME="op-scim-bridge"
-CHART_VERSION="2.10.1"
+CHART_VERSION="2.10.2"
 
 RELEASE="op-scim-bridge"
 NAMESPACE="op-scim-bridge"


### PR DESCRIPTION
## BACKGROUND
* Bumping the helm chart version

-----------------------------------------------------------------------

## Changes
* Update SCIM bridge version to 2.8.2 (Helm 2.10.2)

-----------------------------------------------------------------------

## Checklist
- [ X] review the [contributing doc](https://github.com/digitalocean/marketplace-kubernetes/blob/master/CONTRIBUTING.md) with steps for both adding or updating your application (if applicable)
------------------------------------------------------------------------

Reviewer: @marketplace-eng
