### PR TITLE
Version bump helm chart to 2.8.3

### DIFF
--- a/stacks/op-scim-bridge/deploy.sh
+++ b/stacks/op-scim-bridge/deploy.sh
@@ -9,7 +9,7 @@ helm repo add "$REPO_NAME" "$REPO_URL"
 helm repo update > /dev/null
 
 CHART_NAME="op-scim-bridge"
-CHART_VERSION="2.10.3"
+CHART_VERSION="2.10.4"
 
 RELEASE="op-scim-bridge"
 NAMESPACE="op-scim-bridge"


### PR DESCRIPTION
## BACKGROUND
* We package our SCIM bridge Kubernetes application with helm. In order to bump the version of our app, we must bump the Helm chart.

-----------------------------------------------------------------------

## Changes
* Bump the version to Helm chart `2.10.4`, which packages SCIM bridge version `2.8.3`.

-----------------------------------------------------------------------

## Checklist
- [X] review the [contributing doc](https://github.com/digitalocean/marketplace-kubernetes/blob/master/CONTRIBUTING.md) with steps for both adding or updating your application (if applicable)
------------------------------------------------------------------------

Reviewer: @marketplace-eng
