### PR TITLE
Fix resource cleanup for multiple stacks

### DIFF
--- a/stacks/jaeger/deploy.sh
+++ b/stacks/jaeger/deploy.sh
@@ -7,15 +7,19 @@ CHART="jaegertracing/jaeger"
 CHART_VERSION="0.28.0"
 NAMESPACE="jaeger"
 
+
+helm repo add jaegertracing https://jaegertracing.github.io/helm-charts --force-update
+helm repo update > /dev/null
+
 if [ -z "${MP_KUBERNETES}" ]; then
   VALUES="values.yaml"
 else
   VALUES="https://raw.githubusercontent.com/digitalocean/marketplace-kubernetes/master/stacks/${STACK}/values.yaml"
 fi
 
-helm install "$CHART" \
+helm upgrade "$STACK" "$CHART" \
+  --atomic \
   --create-namespace \
-  --generate-name \
   --namespace "$NAMESPACE" \
   --values "$VALUES" \
   --version "$CHART_VERSION" \

--- a/stacks/jaeger/uninstall.sh
+++ b/stacks/jaeger/uninstall.sh
@@ -1,13 +1,12 @@
 #!/bin/sh
 
-set -eu
+set -e
 
 ################################################################################
 # chart
 ################################################################################
-STACK="otomi"
-NAMESPACE="otomi"
-
+STACK="jaeger"
+NAMESPACE="jaeger"
 
 helm uninstall "$STACK" \
   --namespace "$NAMESPACE"

--- a/stacks/kotal/uninstall.sh
+++ b/stacks/kotal/uninstall.sh
@@ -11,4 +11,4 @@ NAMESPACE="kotal"
 
 helm uninstall "$STACK" \
   --namespace "$NAMESPACE"
-kubectl delete --ignore-not-found=true namespace "$NAMESPACE"
+kubectl delete --ignore-not-found=true namespace "$NAMESPACE" traefik

--- a/stacks/otomi/deploy.sh
+++ b/stacks/otomi/deploy.sh
@@ -13,7 +13,7 @@ helm repo update > /dev/null
 ################################################################################
 STACK="otomi"
 CHART="otomi/otomi"
-NAMESPACE="default"
+NAMESPACE="otomi"
 VERSION="1.24"
 
 if [ -z "${MP_KUBERNETES}" ]; then
@@ -26,9 +26,10 @@ else
 fi
 
 helm upgrade "$STACK" "$CHART" \
+  --atomic \
   --create-namespace \
   --install \
   --timeout 8m0s \
   --namespace "$NAMESPACE" \
   --set cluster.k8sVersion="$VERSION" \
-  --values "$values" 
+  --values "$values"

--- a/stacks/triliovault-operator/uninstall.sh
+++ b/stacks/triliovault-operator/uninstall.sh
@@ -7,7 +7,7 @@ set -e
 ################################################################################
 STACK="triliovault-operator"
 NAMESPACE="tvk"
-ROOT_DIR=$(git rev-parse --show-toplevel)
+#ROOT_DIR=$(git rev-parse --show-toplevel)
 
 echo "Make sure that there are no backups in inprogress state"
 

--- a/stacks/victoria-metrics-cluster/deploy.sh
+++ b/stacks/victoria-metrics-cluster/deploy.sh
@@ -2,6 +2,11 @@
 
 set -e
 
+
+STACK="vmoperator"
+CHART="vm/victoria-metrics-operator"
+NAMESPACE="victoria-metrics"
+
 ################################################################################
 # Add VictoriaMetrics Helm repository
 ################################################################################
@@ -11,7 +16,12 @@ helm repo update > /dev/null
 ################################################################################
 # Install vmoperator from the Helm chart
 ################################################################################
-helm install -n default vmoperator vm/victoria-metrics-operator
+helm upgrade "$STACK" "$CHART" \
+  --atomic \
+  --create-namespace \
+  --install \
+  --namespace "$NAMESPACE" \
+  --wait
 
 # Install VictoriaMetrics Cluster with CRDs
 if [ -z "${MP_KUBERNETES}" ]; then
@@ -19,10 +29,10 @@ if [ -z "${MP_KUBERNETES}" ]; then
   ROOT_DIR=$(git rev-parse --show-toplevel)
   VMCLUSTER="$ROOT_DIR/stacks/victoria-metrics-cluster/yaml/vmcluster.yaml"
   VMAGENT="$ROOT_DIR/stacks/victoria-metrics-cluster/yaml/vmagent.yaml"
-  kubectl apply -f "$VMCLUSTER"
-  kubectl apply -f "$VMAGENT"
+  kubectl apply -n "$NAMESPACE" -f "$VMCLUSTER"
+  kubectl apply -n "$NAMESPACE" -f "$VMAGENT"
 else
   # use github hosted master version of values.yml
-  kubectl apply -n default -f https://raw.githubusercontent.com/digitalocean/marketplace-kubernetes/master/stacks/victoria-metrics-cluster/yaml/vmcluster.yaml
-  kubectl apply -n default -f https://raw.githubusercontent.com/digitalocean/marketplace-kubernetes/master/stacks/victoria-metrics-cluster/yaml/vmagent.yaml
+  kubectl apply -n "$NAMESPACE" -f https://raw.githubusercontent.com/digitalocean/marketplace-kubernetes/master/stacks/victoria-metrics-cluster/yaml/vmcluster.yaml
+  kubectl apply -n "$NAMESPACE" -f https://raw.githubusercontent.com/digitalocean/marketplace-kubernetes/master/stacks/victoria-metrics-cluster/yaml/vmagent.yaml
 fi

--- a/stacks/victoria-metrics-cluster/uninstall.sh
+++ b/stacks/victoria-metrics-cluster/uninstall.sh
@@ -1,13 +1,12 @@
 #!/bin/sh
 
-set -eu
+set -e
 
 ################################################################################
 # chart
 ################################################################################
-STACK="otomi"
-NAMESPACE="otomi"
-
+STACK="vmoperator"
+NAMESPACE="victoria-metrics"
 
 helm uninstall "$STACK" \
   --namespace "$NAMESPACE"


### PR DESCRIPTION
## BACKGROUND
* Some kubernetes stacks do not have an uninstall script, causing some resources to remain on the cluster during the addon testing jobs runs
* Some uninstall scripts fail which again, prevents cleanup of the resources provisioned by the stack

-----------------------------------------------------------------------

## Changes
* Added uninstall scripts to jaeger and victoria-metrics-server
* Fixed existing uninstall scripts
* Updated deploy scripts to use dedicated namespaces rather the default namespace

-----------------------------------------------------------------------

Reviewer: @marketplace-eng
