### PR TITLE
add kubearmor operator to digital ocean

### DIFF
--- a/stacks/kubearmor-operator/deploy.sh
+++ b/stacks/kubearmor-operator/deploy.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+
+set -e
+
+################################################################################
+# repo
+################################################################################
+helm repo add kubearmor https://kubearmor.github.io/charts
+helm repo update > /dev/null
+
+################################################################################
+# chart
+################################################################################
+STACK="kubearmor-operator"
+CHART="kubearmor/kubearmor-operator"
+CHART_VERSION="v1.0.1"
+NAMESPACE="kubearmor"
+
+if [ -z "${MP_KUBERNETES}" ]; then
+  # use local version of values.yml
+  ROOT_DIR=$(git rev-parse --show-toplevel)
+  values="$ROOT_DIR/stacks/kubearmor-operator/values.yml"
+else
+  # use github hosted master version of values.yml
+  values="https://raw.githubusercontent.com/digitalocean/marketplace-kubernetes/master/stacks/kubearmor-operator/values.yml"
+fi
+
+helm upgrade "$STACK" "$CHART" \
+  --atomic \
+  --create-namespace \
+  --install \
+  --timeout 8m0s \
+  --namespace "$NAMESPACE" \
+  --values "$values" \
+  --version "$CHART_VERSION"

--- a/stacks/kubearmor-operator/uninstall.sh
+++ b/stacks/kubearmor-operator/uninstall.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+set -e
+
+################################################################################
+# chart
+################################################################################
+STACK="kubearmor-operator"
+NAMESPACE="kubearmor"
+
+
+helm uninstall "$STACK" \
+  --namespace "$NAMESPACE"

--- a/stacks/kubearmor-operator/upgrade.sh
+++ b/stacks/kubearmor-operator/upgrade.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+set -e
+
+################################################################################
+# repo
+################################################################################
+helm repo add kubearmor https://kubearmor.github.io/charts
+helm repo update > /dev/null
+
+################################################################################
+# chart
+################################################################################
+STACK="kubearmor-operator"
+CHART="kubearmor/kubearmor-operator"
+NAMESPACE="kubearmor"
+
+if [ -z "${MP_KUBERNETES}" ]; then
+    # use local version of values.yml
+    ROOT_DIR=$(git rev-parse --show-toplevel)
+    values="$ROOT_DIR/stacks/kubearmor-operator/values.yml"
+else
+    # use github hosted master version of values.yml
+    values="https://raw.githubusercontent.com/digitalocean/marketplace-kubernetes/master/stacks/kubearmor-operator/values.yml"
+fi
+
+helm upgrade "$STACK" "$CHART" \
+--namespace "$NAMESPACE" \
+--values "$values" \

--- a/stacks/kubearmor-operator/values.yml
+++ b/stacks/kubearmor-operator/values.yml
@@ -1,0 +1,18 @@
+# kubearmor/kubearmor-operator
+autoDeploy: true
+
+kubearmorOperator:
+  name: kubearmor-operator
+  image:
+    repository: kubearmor/kubearmor-operator
+    tag: latest
+  imagePullPolicy: IfNotPresent
+
+kubearmorConfig:
+  defaultCapabilitiesPosture: audit
+  defaultFilePosture: audit
+  defaultNetworkPosture: audit
+  defaultVisibility: process,network
+  enableStdOutLogs: false
+  enableStdOutAlerts: false
+  enableStdOutMsgs: false


### PR DESCRIPTION
## BACKGROUND
* KubeArmor is a cloud-native runtime security enforcement system that restricts the behavior (such as process execution, file access, and networking operations) of pods, containers, and nodes (VMs) at the system level.

-----------------------------------------------------------------------

## Changes
- Add `kubearmor-operator` to digital ocean marketplace, by adding the following:

```
    stacks/kubearmor-operator/deploy.sh
    stacks/kubearmor-operator/upgrade.sh
    stacks/kubearmor-operator/uninstall.sh
    stacks/kubearmor-operator/values.yml
```

-----------------------------------------------------------------------

## Checklist
- [x] review the [contributing doc](https://github.com/digitalocean/marketplace-kubernetes/blob/master/CONTRIBUTING.md) with steps for both adding or updating your application (if applicable)
------------------------------------------------------------------------

Reviewer: @marketplace-eng
