### PR TITLE
Update k8s apps to the latest version

### DIFF
--- a/stacks/ambassador/deploy.sh
+++ b/stacks/ambassador/deploy.sh
@@ -13,7 +13,7 @@ helm repo update > /dev/null
 ################################################################################
 STACK="edge-stack"
 CHART="datawire/edge-stack"
-CHART_VERSION="7.3.2"
+CHART_VERSION="8.7.2"
 NAMESPACE="ambassador"
 
 if [ -z "${MP_KUBERNETES}" ]; then
@@ -26,7 +26,7 @@ else
 fi
 
 # Before installing Ambassador 2.X itself, you must configure your Kubernetes cluster to support the getambassador.io/v3alpha1 and getambassador.io/v2 configuration resources. This is required.
-kubectl apply -f https://app.getambassador.io/yaml/edge-stack/2.3.0/aes-crds.yaml
+kubectl apply -f https://app.getambassador.io/yaml/edge-stack/3.7.2/aes-crds.yaml
 
 helm upgrade "$STACK" "$CHART" \
   --atomic \

--- a/stacks/apache-pulsar/deploy.sh
+++ b/stacks/apache-pulsar/deploy.sh
@@ -13,7 +13,7 @@ helm repo update > /dev/null
 ################################################################################
 STACK="apache-pulsar"
 CHART="apache/pulsar"
-CHART_VERSION="3.0.0"
+CHART_VERSION="3.1.0"
 NAMESPACE="pulsar"
 
 if [ -z "${MP_KUBERNETES}" ]; then

--- a/stacks/cert-manager/deploy.sh
+++ b/stacks/cert-manager/deploy.sh
@@ -13,7 +13,7 @@ helm repo update > /dev/null
 ################################################################################
 STACK="cert-manager"
 CHART="jetstack/cert-manager"
-CHART_VERSION="1.11.0"
+CHART_VERSION="1.13.3"
 NAMESPACE="cert-manager"
 
 if [ -z "${MP_KUBERNETES}" ]; then

--- a/stacks/ingress-nginx/deploy.sh
+++ b/stacks/ingress-nginx/deploy.sh
@@ -13,7 +13,7 @@ helm repo update > /dev/null
 ################################################################################
 STACK="ingress-nginx"
 CHART="ingress-nginx/ingress-nginx"
-CHART_VERSION="4.8.2"
+CHART_VERSION="4.9.0"
 NAMESPACE="ingress-nginx"
 
 if [ -z "${MP_KUBERNETES}" ]; then

--- a/stacks/knative/deploy.sh
+++ b/stacks/knative/deploy.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-OPERATOR_VERSION="1.10.0"
+OPERATOR_VERSION="1.11.6"
 
 kubectl apply -f "https://github.com/knative/serving/releases/download/knative-v${OPERATOR_VERSION}/serving-crds.yaml"
 kubectl apply -f "https://github.com/knative/serving/releases/download/knative-v${OPERATOR_VERSION}/serving-core.yaml"

--- a/stacks/kube-prometheus-stack/deploy.sh
+++ b/stacks/kube-prometheus-stack/deploy.sh
@@ -13,7 +13,7 @@ helm repo update > /dev/null
 ################################################################################
 STACK="kube-prometheus-stack"
 CHART="prometheus-community/kube-prometheus-stack"
-CHART_VERSION="45.10.1"
+CHART_VERSION="55.7.0"
 NAMESPACE="kube-prometheus-stack"
 
 if [ -z "${MP_KUBERNETES}" ]; then

--- a/stacks/kube-state-metrics/deploy.sh
+++ b/stacks/kube-state-metrics/deploy.sh
@@ -13,8 +13,8 @@ helm repo update > /dev/null
 ################################################################################
 STACK="kube-state-metrics"
 CHART="bitnami/kube-state-metrics"
-CHART_VERSION="3.2.0"
-NAMESPACE="kube-system"
+CHART_VERSION="3.8.6"
+NAMESPACE="kube-state-metrics"
 
 if [ -z "${MP_KUBERNETES}" ]; then
   # use local version of values.yml

--- a/stacks/kube-state-metrics/uninstall.sh
+++ b/stacks/kube-state-metrics/uninstall.sh
@@ -6,7 +6,7 @@ set -e
 # chart
 ################################################################################
 STACK="kube-state-metrics"
-NAMESPACE="kube-system"
+NAMESPACE="kube-state-metrics"
 
 
 helm uninstall "$STACK" \

--- a/stacks/metrics-server/deploy.sh
+++ b/stacks/metrics-server/deploy.sh
@@ -13,7 +13,7 @@ helm repo update > /dev/null
 ################################################################################
 STACK="metrics-server"
 CHART="metrics-server/metrics-server"
-CHART_VERSION="3.10.0"
+CHART_VERSION="3.11.0"
 NAMESPACE="metrics-server"
 
 if [ -z "${MP_KUBERNETES}" ]; then

--- a/stacks/openebs-nfs-provisioner/deploy.sh
+++ b/stacks/openebs-nfs-provisioner/deploy.sh
@@ -13,7 +13,7 @@ helm repo update > /dev/null
 ################################################################################
 STACK="openebs-nfs-provisioner"
 CHART="openebs-nfs/nfs-provisioner"
-CHART_VERSION="0.9.0"
+CHART_VERSION="0.11.0"
 NAMESPACE="openebs-nfs-provisioner"
 
 if [ -z "${MP_KUBERNETES}" ]; then

--- a/stacks/wordpress-kubernetes/deploy.sh
+++ b/stacks/wordpress-kubernetes/deploy.sh
@@ -13,7 +13,7 @@ helm repo update > /dev/null
 ################################################################################
 STACK="wordpress-kubernetes"
 CHART="bitnami/wordpress"
-CHART_VERSION="15.0.11"
+CHART_VERSION="19.0.4"
 NAMESPACE="wordpress"
 
 if [ -z "${MP_KUBERNETES}" ]; then


### PR DESCRIPTION
## BACKGROUND
* Some apps in the repo are outdated and need to be updated.

-----------------------------------------------------------------------

## Changes
* Updated the following apps to the latest version
    - Prometheus Kubernetes
    - NFS Provisioner for Kubernetes
    - Ambassador Ingress Controller
    - Knative
    - WordPress 
    - kube-state-metrics
    - Kubernetes Monitoring Stack
    - Apache Pulsar
    - Kubernetes Metrics Server
    - Cert-Manager
    - NGINX Ingress Controller
* Updated the namespace for kube-state-metrics to prevent the uninstall script from failing.

-----------------------------------------------------------------------

## Checklist
- [x] review the [contributing doc](https://github.com/digitalocean/marketplace-kubernetes/blob/master/CONTRIBUTING.md) with steps for both adding or updating your application (if applicable)
------------------------------------------------------------------------

Reviewer: @marketplace-eng
