### PR TITLE
Kubernetes dashboard 1-click for DOKS

### DIFF
--- a/stacks/kubernetes-dashboard/README.md
+++ b/stacks/kubernetes-dashboard/README.md
@@ -1,0 +1,77 @@
+# Dashboard 1-click for DigitalOcean Kubernetes
+
+This addon allows you to easily install the Kubernetes Dashboard Helm chart on your DigitalOcean Kubernetes cluster. 
+
+The Kubernetes Dashboard offers a user-friendly, web-based interface for managing and monitoring your Kubernetes cluster. It allows you to:
+- Visualize your cluster resources, including pods, deployments, services, and nodes.
+- Debug applications by viewing logs and resource metrics.
+- Manage deployments, rolling updates, and service configuration.
+- Gain insights into cluster health and performance.
+
+## Prerequisites
+
+Before using this addon, please ensure the following prerequisites are met:
+
+1. **Helm 3:** Make sure you have Helm 3 installed on your local machine.
+
+2. **Kubernetes Cluster:** Ensure that you have access to your DigitalOcean Kubernetes cluster, and your kubeconfig is properly configured to interact with the cluster.
+
+## Installation
+
+You can install the Kubernetes Dashboard by following these steps:
+
+1. Verify your DigitalOcean Kubernetes cluster's version:
+
+   ```bash
+   kubectl version --short
+   ```
+
+2. Run **deploy.sh**. This basically runs the following. Note that we are explicitly installing the latest version of the dashboard. 
+
+   ```bash
+   helm upgrade --install kubernetes-dashboard kubernetes-dashboard/kubernetes-dashboard \
+     --create-namespace \
+     --namespace kubernetes-dashboard \
+     --set app.ingress.enabled=false \
+     --set metrics-server.enabled=false \
+     --set cert-manager.enabled=false \
+     --set nginx.enabled=false
+   ```
+
+4. Port-forward the Kubernetes Dashboard to your local machine:
+
+   ```bash
+   export POD_NAME=$(kubectl get pods -n kubernetes-dashboard -l "app.kubernetes.io/name=kubernetes-dashboard,app.kubernetes.io/instance=kubernetes-dashboard" -o jsonpath="{.items[0].metadata.name}")
+   kubectl -n kubernetes-dashboard port-forward $POD_NAME 8443:8443
+   ```
+
+5. Access the Kubernetes Dashboard from your local browser at `https://127.0.0.1:8443/`. You may encounter a certificate warning, so make sure to override it.
+
+6. To authenticate, use the Kubernetes configuration file for your cluster, which can be downloaded from the DigitalOcean Kubernetes cloud console for your cluster. You need to choose "manual authentication" and then you can see the option to download the config file.
+
+## Custom Configuration
+
+If you want to reinstall the Kubernetes Dashboard with custom configuration, follow these steps:
+
+1. Update the `values.yaml` file to your preferences. [Reference values.yaml](https://raw.githubusercontent.com/kubernetes/dashboard/master/charts/helm-chart/kubernetes-dashboard/values.yaml)
+
+2. Upgrade the Kubernetes Dashboard with **upgrade.sh** script. That essentially runs the following.
+
+   ```bash
+   helm upgrade --install kubernetes-dashboard kubernetes-dashboard/kubernetes-dashboard \
+     --create-namespace \
+     --namespace kubernetes-dashboard -f values.yaml
+   ```
+
+## Uninstallation
+
+To remove the Kubernetes Dashboard Helm chart, use ./uninstall.sh script. That runs the following command.
+
+```bash
+helm uninstall kubernetes-dashboard -n kubernetes-dashboard
+```
+
+Please note that the dashboard installed by default does not have a public endpoint. If you require one, you'll need to install Nginx, Cert-Manager, and configure the `values.yaml` file as part of the installation process.
+
+For more information about the Kubernetes Dashboard, refer to the [official documentation](https://github.com/kubernetes/dashboard/releases/tag/v3.0.0-alpha0) or the Helm chart on [ArtifactHub](https://artifacthub.io/packages/helm/k8s-dashboard/kubernetes-dashboard).
+

--- a/stacks/kubernetes-dashboard/deploy.sh
+++ b/stacks/kubernetes-dashboard/deploy.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+set -e
+
+################################################################################
+# repo
+################################################################################
+helm repo add kubernetes-dashboard https://kubernetes.github.io/dashboard/
+helm repo update > /dev/null
+
+################################################################################
+# chart
+################################################################################
+STACK="kubernetes-dashboard"
+CHART="kubernetes-dashboard/kubernetes-dashboard"
+CHART_VERSION="7.0.0-alpha1"
+NAMESPACE="kubernetes-dashboard"
+
+if [ -z "${MP_KUBERNETES}" ]; then
+  # use local version of values.yml
+  ROOT_DIR=$(git rev-parse --show-toplevel)
+  values="$ROOT_DIR/stacks/kubernetes-dashboard/values.yml"
+else
+  # use github hosted master version of values.yml
+  values="https://raw.githubusercontent.com/digitalocean/marketplace-kubernetes/master/stacks/kubernetes-dashboard/values.yml"
+fi
+
+helm upgrade "$STACK" "$CHART" \
+  --atomic \
+  --create-namespace \
+  --install \
+  --timeout 8m0s \
+  --namespace "$NAMESPACE" \
+  --values "$values" \
+
+
+# We are deliberately commenting out the chart version to install the latest version of the dashboard
+#  --version "$CHART_VERSION"

--- a/stacks/kubernetes-dashboard/uninstall.sh
+++ b/stacks/kubernetes-dashboard/uninstall.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+set -e
+
+################################################################################
+# chart
+################################################################################
+STACK="kubernetes-dashboard"
+NAMESPACE="kubernetes-dashboard"
+
+
+helm uninstall "$STACK" \
+  --namespace "$NAMESPACE"

--- a/stacks/kubernetes-dashboard/upgrade.sh
+++ b/stacks/kubernetes-dashboard/upgrade.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+set -e
+
+################################################################################
+# repo
+################################################################################
+helm repo add kubernetes-dashboard https://kubernetes.github.io/dashboard/
+helm repo update > /dev/null
+
+################################################################################
+# chart
+################################################################################
+STACK="kubernetes-dashboard"
+CHART="kubernetes-dashboard/kubernetes-dashboard"
+NAMESPACE="kubernetes-dashboard"
+
+if [ -z "${MP_KUBERNETES}" ]; then
+    # use local version of values.yml
+    ROOT_DIR=$(git rev-parse --show-toplevel)
+    values="$ROOT_DIR/stacks/kubernetes-dashboard/values.yml"
+else
+    # use github hosted master version of values.yml
+    values="https://raw.githubusercontent.com/digitalocean/marketplace-kubernetes/master/stacks/kubernetes-dashboard/values.yml"
+fi
+
+helm upgrade "$STACK" "$CHART" \
+--namespace "$NAMESPACE" \
+--values "$values" \

--- a/stacks/kubernetes-dashboard/values.yml
+++ b/stacks/kubernetes-dashboard/values.yml
@@ -1,0 +1,17 @@
+# kubernetes-dashboard/kubernetes-dashboard
+# Reference source: https://raw.githubusercontent.com/kubernetes/dashboard/master/charts/helm-chart/kubernetes-dashboard/values.yaml
+# Alternately you get get the default values.yaml by using: helm pull kubernetes-dashboard/kubernetes-dashboard --untar. This will download the entire package to your local directory
+
+
+app:
+  ingress:
+    enabled: false
+
+metricsScraper:
+  enabled: false
+
+nginx:
+  enabled: false
+
+cert-manager:
+  enabled: false


### PR DESCRIPTION
## BACKGROUND
* We are deprecating the dashboard feature from DOKS. This 1-click will be the alternative recommendation going forward.

https://do-internal.atlassian.net/browse/CON-9679


-----------------------------------------------------------------------

## Changes
* Added stacks/kubernetes-dashboard
* Tested with DOKS 1.26, 1.27 and 1.28 versions

-----------------------------------------------------------------------

## Checklist
- [ ] review the [contributing doc](https://github.com/digitalocean/marketplace-kubernetes/blob/master/CONTRIBUTING.md) with steps for both adding or updating your application (if applicable)
------------------------------------------------------------------------

Reviewer: @marketplace-eng
