### PR TITLE
Updating heml chart version to 2.11.0

### DIFF
--- a/stacks/op-scim-bridge/deploy.sh
+++ b/stacks/op-scim-bridge/deploy.sh
@@ -9,7 +9,7 @@ helm repo add "$REPO_NAME" "$REPO_URL"
 helm repo update > /dev/null
 
 CHART_NAME="op-scim-bridge"
-CHART_VERSION="2.10.5"
+CHART_VERSION="2.11.0"
 
 RELEASE="op-scim-bridge"
 NAMESPACE="op-scim-bridge"


### PR DESCRIPTION
## BACKGROUND
* v2.11.0 of our helm chart had an error presented to Digital Ocean customers. This update brings the version forward to a helm chart version which corrects the error and updates the values.yml to prevent further errors of this kind..

-----------------------------------------------------------------------

## Changes
- Docker images now support arm64 architectures.
- Logs now include the hostname and a unique instance_id for easier identification in deployments with multiple replicas.
- Return a more detailed and appropriate response when failing to reactivate users. {3878}
- URL validators for Google Workspace configurations now provide more actionable error messages. {2872}
- Improved clarity and accuracy of Google Workspace group tables member count. {2873}
- Fixed: Changing a group name will now succeed on retry when there is missing data in the redis cache. {3817}
- Fixed: OP_REDIS_ENABLE_SSL now functions as expected. {3915}

-----------------------------------------------------------------------

## Checklist
- [x] review the [contributing doc](https://github.com/digitalocean/marketplace-kubernetes/blob/master/CONTRIBUTING.md) with steps for both adding or updating your application (if applicable)
------------------------------------------------------------------------

Reviewer: @marketplace-eng
