### PR TITLE
kubefirst upgrade to 2.4.6

### DIFF
--- a/stacks/kubefirst/deploy.sh
+++ b/stacks/kubefirst/deploy.sh
@@ -13,7 +13,7 @@ helm repo update > /dev/null
 ################################################################################
 STACK="kubefirst"
 CHART="kubefirst/kubefirst"
-CHART_VERSION="2.3.7"
+CHART_VERSION="2.4.6"
 NAMESPACE="kubefirst"
 
 if [ -z "${MP_KUBERNETES}" ]; then


### PR DESCRIPTION
## BACKGROUND
* addition of akamai cloud and k3s bare metal support for digitalocean management clusters

-----------------------------------------------------------------------

## Changes
* the 2.4 release introduces k3s cluster provisioning for unsupported clouds, native akamai support, reduced permissions in the management cluster, and an improved gitops catalog experience
-----------------------------------------------------------------------

## Checklist
- [x] review the [contributing doc](https://github.com/digitalocean/marketplace-kubernetes/blob/master/CONTRIBUTING.md) with steps for both adding or updating your application (if applicable)
------------------------------------------------------------------------

Reviewer: @marketplace-eng
