### PR TITLE
Release for 2.9.3

### DIFF
--- a/stacks/op-scim-bridge/deploy.sh
+++ b/stacks/op-scim-bridge/deploy.sh
@@ -9,7 +9,7 @@ helm repo add "$REPO_NAME" "$REPO_URL"
 helm repo update > /dev/null
 
 CHART_NAME="op-scim-bridge"
-CHART_VERSION="2.11.1"
+CHART_VERSION="2.11.2"
 
 RELEASE="op-scim-bridge"
 NAMESPACE="op-scim-bridge"


### PR DESCRIPTION
## BACKGROUND
* Bumped version of packaged Helm chart to `2.11.2`, containing SCIM bridge `2.9.3`

-----------------------------------------------------------------------

## Changes
* Helm chart version bump: https://github.com/1Password/op-scim-helm/releases

-----------------------------------------------------------------------

## Checklist
- [X] review the [contributing doc](https://github.com/digitalocean/marketplace-kubernetes/blob/master/CONTRIBUTING.md) with steps for both adding or updating your application (if applicable)
------------------------------------------------------------------------

Reviewer: @marketplace-eng
