### PR TITLE
bump VictoriaMetrics Cluster components, vmagent and operator to the latest versions

### DIFF
--- a/stacks/victoria-metrics-cluster/README.md
+++ b/stacks/victoria-metrics-cluster/README.md
@@ -1,6 +1,6 @@
 ## Application summary
 
-VictoriaMetrics Cluster is a fast and scalable open source time series database and monitoring solution.
+[VictoriaMetrics Cluster](https://docs.victoriametrics.com/cluster-victoriametrics/) is a fast and scalable open source time series database and monitoring solution.
 
 ## Description
 
@@ -8,7 +8,7 @@ VictoriaMetrics Cluster is a free, [open source time series database](https://en
 designed to collect, store and process real-time metrics.
 
 It supports the [Prometheus](https://en.wikipedia.org/wiki/Prometheus_(software)) pull model and various push protocols ([Graphite](https://en.wikipedia.org/wiki/Graphite_(software)), [InfluxDB](https://en.wikipedia.org/wiki/InfluxDB), OpenTSDB) 
-for data ingestion. It is optimized for storage with high-latency IO, low IOPS and time series with [high churn rate](https://docs.victoriametrics.com/FAQ.html#what-is-high-churn-rate).
+for data ingestion. It is optimized for storage with high-latency IO, low IOPS and time series with [high churn rate](https://docs.victoriametrics.com/faq/#what-is-high-churn-rate).
 
 For reading the data and evaluating alerting rules, VictoriaMetrics supports the PromQL, MetricsQL and Graphite query languages.
 VictoriaMetrics Cluster is fully autonomous and can be used as a long-term storage for time series. It supports all features of VictoriaMetrics Single;
@@ -24,11 +24,11 @@ The VictoriaMetrics Cluster database requires at least two replicas to function
 effectively. The operator will make it's best effort to spread all components
 across nodes to ensure availability.
 
-[VictoriaMetrics Cluster](https://docs.victoriametrics.com/Cluster-VictoriaMetrics.html)  =  Highly available horizontally scalable monitoring solution optimized for high performance.  Supports multiple independent namespaces (aka multi-tenancy) and replication. Cluster version is preferable for large or rapidly growing environments.
+[VictoriaMetrics Cluster](https://docs.victoriametrics.com/cluster-victoriametrics/)  =  Highly available horizontally scalable monitoring solution optimized for high performance.  Supports multiple independent namespaces (aka multi-tenancy) and replication. Cluster version is preferable for large or rapidly growing environments.
 
-[vmgent](https://docs.victoriametrics.com/vmagent.html) = Lightweight agent that helps users collect metrics from various sources and store them in VictoriaMetrics or any other Prometheus-compatible storage systems.
+[vmgent](https://docs.victoriametrics.com/vmagent/) = Lightweight agent that helps users collect metrics from various sources and store them in VictoriaMetrics or any other Prometheus-compatible storage systems.
 
-[vmperator](https://github.com/VictoriaMetrics/operator) = Kubernetes operator for Victoria Metrics = is a tool that creates/configures/manages VictoriaMetrics Cluster's atop Kubernetes.
+[vmperator](https://docs.victoriametrics.com/operator/) = Kubernetes operator for Victoria Metrics = is a tool that creates/configures/manages VictoriaMetrics Cluster's atop Kubernetes.
 
 **Software Included:**
 

--- a/stacks/victoria-metrics-cluster/README.md
+++ b/stacks/victoria-metrics-cluster/README.md
@@ -34,9 +34,9 @@ across nodes to ensure availability.
 
 | Package  | Version | License |
 | ------------- | ------------- | ------------- |
-| VictoriaMetrics Cluster  | [1.102.1](https://docs.victoriametrics.com/changelog/#v11021)  | Apache 2.0  |
-| vmagent  | [1.102.1](https://docs.victoriametrics.com/changelog/#v11021)  | Apache 2.0  |
-| vmoperator  | [0.47.0](https://github.com/VictoriaMetrics/operator/releases/tag/v0.47.0)  | Apache 2.0  |
+| VictoriaMetrics Cluster  | [1.103.0](hhttps://docs.victoriametrics.com/changelog/#v11030)  | Apache 2.0  |
+| vmagent  | [1.103.0](https://docs.victoriametrics.com/changelog/#v11030)  | Apache 2.0  |
+| vmoperator  | [0.48.3](https://docs.victoriametrics.com/operator/changelog/#v0483---29-sep-2024)  | Apache 2.0  |
 
 ## Getting started after deploying VictoriaMetrics Cluster
 

--- a/stacks/victoria-metrics-cluster/README.md
+++ b/stacks/victoria-metrics-cluster/README.md
@@ -34,9 +34,9 @@ across nodes to ensure availability.
 
 | Package  | Version | License |
 | ------------- | ------------- | ------------- |
-| VictoriaMetrics Cluster  | [1.96.0](https://docs.victoriametrics.com/CHANGELOG_2023.html#v1960)  | Apache 2.0  |
-| vmagent  | [1.96.0](https://docs.victoriametrics.com/CHANGELOG_2023.html#v1960)  | Apache 2.0  |
-| vmoperator  | [0.40.0](https://github.com/VictoriaMetrics/operator/releases/tag/v0.40.0)  | Apache 2.0  |
+| VictoriaMetrics Cluster  | [1.102.1](https://docs.victoriametrics.com/changelog/#v11021)  | Apache 2.0  |
+| vmagent  | [1.102.1](https://docs.victoriametrics.com/changelog/#v11021)  | Apache 2.0  |
+| vmoperator  | [0.47.0](https://github.com/VictoriaMetrics/operator/releases/tag/v0.47.0)  | Apache 2.0  |
 
 ## Getting started after deploying VictoriaMetrics Cluster
 

--- a/stacks/victoria-metrics-cluster/yaml/vmagent.yaml
+++ b/stacks/victoria-metrics-cluster/yaml/vmagent.yaml
@@ -7,6 +7,6 @@ spec:
   replicaCount: 1
   image:
     repository: victoriametrics/vmagent
-    tag: v1.102.1
+    tag: v1.103.0
   remoteWrite:
     - url: "http://vminsert-vmcluster.default.svc.cluster.local:8480/insert/0/prometheus/"

--- a/stacks/victoria-metrics-cluster/yaml/vmagent.yaml
+++ b/stacks/victoria-metrics-cluster/yaml/vmagent.yaml
@@ -7,6 +7,6 @@ spec:
   replicaCount: 1
   image:
     repository: victoriametrics/vmagent
-    tag: v1.96.0
+    tag: v1.102.1
   remoteWrite:
     - url: "http://vminsert-vmcluster.default.svc.cluster.local:8480/insert/0/prometheus/"

--- a/stacks/victoria-metrics-cluster/yaml/vmcluster.yaml
+++ b/stacks/victoria-metrics-cluster/yaml/vmcluster.yaml
@@ -8,14 +8,14 @@ spec:
       replicaCount: 2
       image:
         repository: victoriametrics/vmstorage
-        tag: v1.96.0-cluster
+        tag: v1.102.1-cluster
   vmselect:
       replicaCount: 2
       image:
         repository: victoriametrics/vmselect
-        tag: v1.96.0-cluster
+        tag: v1.102.1-cluster
   vminsert:
       replicaCount: 2
       image:
         repository: victoriametrics/vminsert
-        tag: v1.96.0-cluster
+        tag: v1.102.1-cluster

--- a/stacks/victoria-metrics-cluster/yaml/vmcluster.yaml
+++ b/stacks/victoria-metrics-cluster/yaml/vmcluster.yaml
@@ -8,14 +8,14 @@ spec:
       replicaCount: 2
       image:
         repository: victoriametrics/vmstorage
-        tag: v1.102.1-cluster
+        tag: v1.103.0-cluster
   vmselect:
       replicaCount: 2
       image:
         repository: victoriametrics/vmselect
-        tag: v1.102.1-cluster
+        tag: v1.103.0-cluster
   vminsert:
       replicaCount: 2
       image:
         repository: victoriametrics/vminsert
-        tag: v1.102.1-cluster
+        tag: v1.103.0-cluster


### PR DESCRIPTION
## BACKGROUND
* Product version update

-----------------------------------------------------------------------

## Changes
* README.md: update version of VictoriaMetrics Cluster, vmagent, operator to the latest versions
* bump [vmagent](https://docs.victoriametrics.com/vmagent.html) version to the latest [v1.102.1](https://docs.victoriametrics.com/changelog/#v11021)
* bump version of [VictoriaMetrics Cluster](https://docs.victoriametrics.com/Cluster-VictoriaMetrics.html) to the latest [v1.102.1](https://docs.victoriametrics.com/changelog/#v11021)
* bump VictoriaMetrics [operator](https://docs.victoriametrics.com/operator/) to the latest [v0.47.0](https://docs.victoriametrics.com/operator/changelog/#v0470---15-aug-2024)
------------------------------------------------------------------------

Reviewer: @marketplace-eng
