### PR TITLE
Update chart version

### DIFF
--- a/stacks/op-scim-bridge/deploy.sh
+++ b/stacks/op-scim-bridge/deploy.sh
@@ -9,7 +9,7 @@ helm repo add "$REPO_NAME" "$REPO_URL"
 helm repo update > /dev/null
 
 CHART_NAME="op-scim-bridge"
-CHART_VERSION="2.11.4"
+CHART_VERSION="2.11.5"
 
 RELEASE="op-scim-bridge"
 NAMESPACE="op-scim-bridge"


### PR DESCRIPTION
## BACKGROUND
* Bumps to version 2.9.5 of the 1Password SCIM bridge.

-----------------------------------------------------------------------

## Changes
* Bump helm version 2.11.5, the [latest of our helm charts](https://github.com/1Password/op-scim-helm/releases/tag/op-scim-bridge-2.11.5)

![image](https://github.com/user-attachments/assets/67eb21c7-9eab-4a77-a31c-03971543de1b)


-----------------------------------------------------------------------

## Checklist
- [x] review the [contributing doc](https://github.com/digitalocean/marketplace-kubernetes/blob/master/CONTRIBUTING.md) with steps for both adding or updating your application (if applicable)
------------------------------------------------------------------------

Reviewer: @marketplace-eng
