### PR TITLE
Update kube-prometheus-stack chart version to 68.1.0

### DIFF
--- a/stacks/kube-prometheus-stack/deploy.sh
+++ b/stacks/kube-prometheus-stack/deploy.sh
@@ -13,7 +13,7 @@ helm repo update > /dev/null
 ################################################################################
 STACK="kube-prometheus-stack"
 CHART="prometheus-community/kube-prometheus-stack"
-CHART_VERSION="55.7.0"
+CHART_VERSION="68.1.0"
 NAMESPACE="kube-prometheus-stack"
 
 if [ -z "${MP_KUBERNETES}" ]; then

--- a/stacks/kube-prometheus-stack/values.yml
+++ b/stacks/kube-prometheus-stack/values.yml
@@ -1,5 +1,5 @@
 ## Stack name: prometheus-community/kube-prometheus-stack
-## Ref: https://github.com/prometheus-community/helm-charts/tree/kube-prometheus-stack-35.5.1/charts/kube-prometheus-stack
+## Ref: https://github.com/prometheus-community/helm-charts/
 ##
 
 


### PR DESCRIPTION
## BACKGROUND

Tested on latest DOKS version `1.31.1-do.5`
Followed steps in Marketplace [listing](https://marketplace.digitalocean.com/apps/kubernetes-monitoring-stack), they still apply

-----------------------------------------------------------------------

## Changes

https://github.com/digitalocean/marketplace-kubernetes/commit/27df259aa07f6ea11497f30c9b04d6c691ddc825
-----------------------------------------------------------------------

## Checklist
- [x] review the [contributing doc](https://github.com/digitalocean/marketplace-kubernetes/blob/master/CONTRIBUTING.md) with steps for both adding or updating your application (if applicable)
------------------------------------------------------------------------

Reviewer: @marketplace-eng
