### PR TITLE
Upgrade Headlamp chart version to 0.27.0

### DIFF
--- a/stacks/headlamp/deploy.sh
+++ b/stacks/headlamp/deploy.sh
@@ -13,7 +13,7 @@ helm repo update > /dev/null
 ################################################################################
 STACK="headlamp"
 CHART="headlamp/headlamp"
-CHART_VERSION="0.25.0"
+CHART_VERSION="0.27.0"
 NAMESPACE="headlamp"
 
 if [ -z "${MP_KUBERNETES}" ]; then


### PR DESCRIPTION
## BACKGROUND
* Headlamp is pointing to chart version 0.25.0 updating it to the latest 0.27.0 version.
-----------------------------------------------------------------------

## Changes
* Update the Headlamp stack chart version.
-----------------------------------------------------------------------

## Checklist
- [x] review the [contributing doc](https://github.com/digitalocean/marketplace-kubernetes/blob/master/CONTRIBUTING.md) with steps for both adding or updating your application (if applicable)
------------------------------------------------------------------------

Reviewer: @marketplace-eng
