### PR TITLE
Pull in latest SCIM version

### DIFF
--- a/stacks/op-scim-bridge/deploy.sh
+++ b/stacks/op-scim-bridge/deploy.sh
@@ -9,7 +9,7 @@ helm repo add "$REPO_NAME" "$REPO_URL"
 helm repo update > /dev/null
 
 CHART_NAME="op-scim-bridge"
-CHART_VERSION="2.11.6"
+CHART_VERSION="2.11.7"
 
 RELEASE="op-scim-bridge"
 NAMESPACE="op-scim-bridge"


### PR DESCRIPTION
## BACKGROUND
* Update SCIM Version

-----------------------------------------------------------------------

## Changes
* Update to latest Helm Chart pulling in SCIM `2.9.9` per https://github.com/1Password/op-scim-helm/releases/tag/op-scim-bridge-2.11.7

-----------------------------------------------------------------------

## Checklist
- [X] review the [contributing doc](https://github.com/digitalocean/marketplace-kubernetes/blob/master/CONTRIBUTING.md) with steps for both adding or updating your application (if applicable)
------------------------------------------------------------------------

Reviewer: @marketplace-eng
