### PR TITLE
K8s NGINX Ingress fix `controller.metrics.service.servicePort`

### DIFF
--- a/stacks/ingress-nginx/values.yml
+++ b/stacks/ingress-nginx/values.yml
@@ -11,10 +11,8 @@ controller:
   ## Enable the metrics of the NGINX Ingress controller https://kubernetes.github.io/ingress-nginx/user-guide/monitoring/
   metrics:
     enabled: true
+    service:
+      servicePort: "9090"
   podAnnotations:
-    controller:
-      metrics:
-        service:
-          servicePort: "9090"
     prometheus.io/port: "10254"
     prometheus.io/scrape: "true"


### PR DESCRIPTION
## BACKGROUND
* Add information about the background and reason for the change.
The key `controller.metrics.service.servicePort` with value `"9090"` should not be part of the `controller.podAnnotations`.
See https://github.com/kubernetes/ingress-nginx/blob/3a9ebee8cd463f35722286d5e1d7c36f0d1d41d6/charts/ingress-nginx/values.yaml#L889
![image](https://github.com/user-attachments/assets/57c7191b-6e0a-47af-8c74-49acd9775521)
-----------------------------------------------------------------------

## Changes
* List the changes that you made
Move key `controller.podAnnotations.controller.metrics.service.servicePort` to `controller.metrics.service.servicePort` where it belongs.
-----------------------------------------------------------------------

## Checklist
- [X] review the [contributing doc](https://github.com/digitalocean/marketplace-kubernetes/blob/master/CONTRIBUTING.md) with steps for both adding or updating your application (if applicable)
------------------------------------------------------------------------

Reviewer: @marketplace-eng
