### PR TITLE
Upgrade the HELM package

### DIFF
--- a/stacks/easyhaproxy/README.md
+++ b/stacks/easyhaproxy/README.md
@@ -5,6 +5,7 @@
 HAProxy is an open-source, high-performance load balancer and reverse proxy designed for TCP and HTTP-based applications. Renowned for its stability, reliability, and performance, it is widely adopted in production environments.
 
 EasyHAProxy combines HAProxy's robustness with seamless service discovery and exposure within Kubernetes clusters. It offers a straightforward method to configure Ingress rules for services.
+
 Key Features
 
 - Handles and routes HTTP, HTTPS, and TCP traffic (e.g., MySQL server).
@@ -18,6 +19,14 @@ Key Features
 
 - Enable the EasyHAProxy in the Digital Ocean marketplace
 - Create a Digital Ocean Load Balance pointing to your Kubernetes Cluster. 
+
+## Deployment Configuration
+
+EasyHAProxy can be deployed in two ways:
+
+1. **Deployment with Service (default in DO Marketplace)**: EasyHAProxy is deployed as a Deployment with a Service (ClusterIP), allowing it to run on any available node in the cluster. This is configured with `service.create: true`.
+
+2. **DaemonSet with node affinity**: For advanced configurations, you can deploy EasyHAProxy as a DaemonSet with node affinity by setting `service.create: false`. In this mode, EasyHAProxy will only run on nodes with the specified label.
 
 ## How to set up your application for EasyHAProxy
 
@@ -41,7 +50,7 @@ For further details about EasyHAProxy, please refer to the [documentation](https
 
 ### Check if the EasyHAProxy is running properly
 
-You can install the "Static Http Server"  and define the domain you want to validate as the example below:
+You can install the "Static Http Server" and define the domain you want to validate as the example below:
 
 ```shell
 helm repo add byjg https://opensource.byjg.com/helm
@@ -52,12 +61,33 @@ helm upgrade --install mysite byjg/static-httpserver \
     --set parameters.title=Welcome
 ```
 
+### EasyHAProxy Configuration
+
+If you need to modify the EasyHAProxy configuration (such as changing log levels or resource requests), you can use the following command:
+
+If you want to use the default values:
+
+```bash
+helm upgrade --install easyhaproxy byjg/easyhaproxy
+```
+
+or if you want to change the default values and replacing by a new ones:
+
+```bash
+helm upgrade --install easyhaproxy byjg/easyhaproxy \
+  --namespace easyhaproxy \
+  --set easyhaproxy.logLevel.certbot=INFO \
+  --set easyhaproxy.logLevel.easyhaproxy=INFO \
+  --set easyhaproxy.logLevel.haproxy=INFO \
+  --set resources.requests.cpu=100m \
+  --set resources.requests.memory=128Mi \
+  --set service.create=true
+```
 
 ### EasyHAProxy Container not Starting
 
-Due to limitations in the HAProxy community edition, EasyHAProxy functions solely as a standalone service, regardless of the number of nodes present.
+When using the DaemonSet deployment mode (`service.create: false`), EasyHAProxy will only run on nodes with the specified label due to HAProxy community edition limitations. 
 
-If the node hosting EasyHAProxy experiences downtime, the service will remain unavailable until the node is operational again.
+If you're using the default Digital Ocean Marketplace configuration (`service.create: true`), EasyHAProxy will run as a regular Deployment with a Service, which provides better resilience as it can be scheduled on any available node in the cluster.
 
-To restore connectivity, you have the option to deploy or upgrade the EasyHAProxy service.
-
+If you experience issues, you can restore connectivity by redeploying or upgrading the EasyHAProxy service using the Helm upgrade command shown above. 

--- a/stacks/easyhaproxy/deploy.sh
+++ b/stacks/easyhaproxy/deploy.sh
@@ -26,7 +26,7 @@ fi
 ################################################################################
 STACK="easyhaproxy"
 CHART="byjg/easyhaproxy"
-CHART_VERSION="0.1.7"
+CHART_VERSION="0.1.8"
 NAMESPACE="easyhaproxy"
 
 if [ -z "${MP_KUBERNETES}" ]; then


### PR DESCRIPTION
## BACKGROUND
* Upgrade the Helm Package from 0.1.7 to 0.1.8.
* Updated the EasyHAProxy documentation to improve clarity around deployment options, particularly regarding the service.create parameter and its relationship with node affinity.
* Added more detailed configuration examples to help users troubleshoot and customize their EasyHAProxy installations.
* Made the documentation more consistent with the latest implementation, which supports both Deployment and DaemonSet modes.

-----------------------------------------------------------------------

## Changes
* Added a new "Deployment Configuration" section explaining the two deployment options (Deployment with Service vs DaemonSet with node affinity)
* Clarified that the Digital Ocean Marketplace default is to use the Deployment with Service model (`service.create: true`)
* Added a new "EasyHAProxy Configuration" section with an example Helm command for modifying configuration settings
* Updated the "EasyHAProxy Container not Starting" section to better explain when issues might occur and how the default DO configuration provides better resilience
* Added information about using `helm upgrade` to restore connectivity when experiencing issues

-----------------------------------------------------------------------

## Checklist
- [x] review the [contributing doc](https://github.com/digitalocean/marketplace-kubernetes/blob/master/CONTRIBUTING.md) with steps for both adding or updating your application (if applicable)
------------------------------------------------------------------------

Reviewer: @marketplace-eng 
