### PR TITLE
Updates for CloudCasa 3.4.4 Helm chart

### DIFF
--- a/stacks/cloudcasa/deploy.sh
+++ b/stacks/cloudcasa/deploy.sh
@@ -13,7 +13,7 @@ helm repo update > /dev/null
 ################################################################################
 STACK="cloudcasa"
 CHART="cloudcasa-helmchart/cloudcasa"
-CHART_VERSION="3.4.2"
+CHART_VERSION="3.4.4"
 NAMESPACE="default"
 
 if [ -z "${MP_KUBERNETES}" ]; then

--- a/stacks/cloudcasa/values.yml
+++ b/stacks/cloudcasa/values.yml
@@ -2,4 +2,4 @@
 ## Current available global Docker image parameters: imageRegistry
 
 ## Cloudcasa AMDS Cluster ID. To be provided by the user.
-cluster_id: ""
+clusterID: ""


### PR DESCRIPTION
## BACKGROUND
* Bump version of CloudCasa agent Helm chart to 3.4.4

-----------------------------------------------------------------------

## Changes
* Update CHART_VERSION to 3.4.4
* Update cluster ID parameter name

-----------------------------------------------------------------------

## Checklist
- [x] review the [contributing doc](https://github.com/digitalocean/marketplace-kubernetes/blob/master/CONTRIBUTING.md) with steps for both adding or updating your application (if applicable)
------------------------------------------------------------------------

Reviewer: @marketplace-eng
