### PR TITLE
Update kube prometheus stack and metrics charts versions

### DIFF
--- a/stacks/kube-prometheus-stack/deploy.sh
+++ b/stacks/kube-prometheus-stack/deploy.sh
@@ -13,7 +13,7 @@ helm repo update > /dev/null
 ################################################################################
 STACK="kube-prometheus-stack"
 CHART="prometheus-community/kube-prometheus-stack"
-CHART_VERSION="68.1.0"
+CHART_VERSION="75.9.0"
 NAMESPACE="kube-prometheus-stack"
 
 if [ -z "${MP_KUBERNETES}" ]; then

--- a/stacks/metrics-server/deploy.sh
+++ b/stacks/metrics-server/deploy.sh
@@ -13,7 +13,7 @@ helm repo update > /dev/null
 ################################################################################
 STACK="metrics-server"
 CHART="metrics-server/metrics-server"
-CHART_VERSION="3.11.0"
+CHART_VERSION="3.12.2"
 NAMESPACE="metrics-server"
 
 if [ -z "${MP_KUBERNETES}" ]; then


### PR DESCRIPTION
## BACKGROUND
* Kubernetes monitoring stack and metrics server are outdated in marketplace and should be updated

-----------------------------------------------------------------------

## Changes
* Update kubernetes monitoring stack to 75.9.0
* Update metrics server to 3.12.2

-----------------------------------------------------------------------

## Checklist
- [ ] review the [contributing doc](https://github.com/digitalocean/marketplace-kubernetes/blob/master/CONTRIBUTING.md) with steps for both adding or updating your application (if applicable)
------------------------------------------------------------------------

Reviewer: @marketplace-eng
