### PR TITLE
Update the 1Password SCIM bridge helm chart to v2.11.10

### DIFF
--- a/stacks/op-scim-bridge/deploy.sh
+++ b/stacks/op-scim-bridge/deploy.sh
@@ -9,7 +9,7 @@ helm repo add "$REPO_NAME" "$REPO_URL"
 helm repo update > /dev/null
 
 CHART_NAME="op-scim-bridge"
-CHART_VERSION="2.11.9"
+CHART_VERSION="2.11.10"
 
 RELEASE="op-scim-bridge"
 NAMESPACE="op-scim-bridge"


### PR DESCRIPTION
## BACKGROUND
* This change features a switch from `bitnami/redis` to `bitnamisecure/redis` docker image and associated dependent helm chart. 

-----------------------------------------------------------------------

## Changes
* Upgrade to [v2.11.10](https://github.com/1Password/op-scim-helm/releases/tag/op-scim-bridge-2.11.10) of the 1Password SCIM Bridge helm chart

-----------------------------------------------------------------------

## Checklist
- [x] review the [contributing doc](https://github.com/digitalocean/marketplace-kubernetes/blob/master/CONTRIBUTING.md) with steps for both adding or updating your application (if applicable)
------------------------------------------------------------------------

Reviewer: @marketplace-eng
