### PR TITLE
MP-8089/DynamicallyPullKnativeVersion

### DIFF
--- a/stacks/knative/deploy.sh
+++ b/stacks/knative/deploy.sh
@@ -2,7 +2,18 @@
 
 set -e
 
-OPERATOR_VERSION="1.20.0"
+# Define the repository
+REPO="knative/operator"
+
+# Fetch the latest release tag name from GitHub API
+OPERATOR_VERSION=$(curl -s "https://api.github.com/repos/$REPO/releases/latest" | \
+    grep '"tag_name":' | \
+    sed -E 's/.*"([^"]+)".*/\1/' | \
+    sed 's/^knative-v//' | \
+    sed 's/^v//')
+
+# Output the version
+echo "$OPERATOR_VERSION"
 
 kubectl apply -f "https://github.com/knative/serving/releases/download/knative-v${OPERATOR_VERSION}/serving-crds.yaml"
 kubectl apply -f "https://github.com/knative/serving/releases/download/knative-v${OPERATOR_VERSION}/serving-core.yaml"
@@ -20,5 +31,3 @@ kubectl apply -f "https://github.com/knative/eventing/releases/download/knative-
 # Deploy Knative Operator
 kubectl apply -f "https://github.com/knative/operator/releases/download/knative-v${OPERATOR_VERSION}/operator.yaml" --wait
 
-## ARTHUR'S NOTES: UNFORTUNATELY KNATIVE DOES NOT SUPPORT HELM FOR EASIER VERSIONING.
-# CONSIDER AN OPTION TO DYNAMICALLY PULL LATEST VERSION FROM KNATIVE RELEASE PAGE

--- a/stacks/knative/deploy.sh
+++ b/stacks/knative/deploy.sh
@@ -3,30 +3,48 @@
 set -e
 
 # Define the repository
-REPO="knative/operator"
+OPERATOR_REPO="knative/operator"
+EVENTING_REPO="knative/eventing"
+SERVING_REPO="knative/serving"
+KOURIER_REPO="knative-extensions/net-kourier"
 
 # Fetch the latest release tag name from GitHub API
-OPERATOR_VERSION=$(curl -s "https://api.github.com/repos/$REPO/releases/latest" | \
+OPERATOR_VERSION=$(curl -s "https://api.github.com/repos/$OPERATOR_REPO/releases/latest" | \
     grep '"tag_name":' | \
     sed -E 's/.*"([^"]+)".*/\1/' | \
     sed 's/^knative-v//' | \
     sed 's/^v//')
 
-# Output the version
-echo "$OPERATOR_VERSION"
+KOURIER_VERSION=$(curl -s "https://api.github.com/repos/$KOURIER_REPO/releases/latest" | \
+    grep '"tag_name":' | \
+    sed -E 's/.*"([^"]+)".*/\1/' | \
+    sed 's/^knative-v//' | \
+    sed 's/^v//')
 
-kubectl apply -f "https://github.com/knative/serving/releases/download/knative-v${OPERATOR_VERSION}/serving-crds.yaml"
-kubectl apply -f "https://github.com/knative/serving/releases/download/knative-v${OPERATOR_VERSION}/serving-core.yaml"
-kubectl apply -f "https://github.com/knative/net-kourier/releases/download/knative-v${OPERATOR_VERSION}/kourier.yaml"
+SERVING_VERSION=$(curl -s "https://api.github.com/repos/$SERVING_REPO/releases/latest" | \
+    grep '"tag_name":' | \
+    sed -E 's/.*"([^"]+)".*/\1/' | \
+    sed 's/^knative-v//' | \
+    sed 's/^v//')
+
+EVENTING_VERSION=$(curl -s "https://api.github.com/repos/$EVENTING_REPO/releases/latest" | \
+    grep '"tag_name":' | \
+    sed -E 's/.*"([^"]+)".*/\1/' | \
+    sed 's/^knative-v//' | \
+    sed 's/^v//')
+
+kubectl apply -f "https://github.com/knative/serving/releases/download/knative-v${SERVING_VERSION}/serving-crds.yaml"
+kubectl apply -f "https://github.com/knative/serving/releases/download/knative-v${SERVING_VERSION}/serving-core.yaml"
+kubectl apply -f "https://github.com/knative/net-kourier/releases/download/knative-v${KOURIER_VERSION}/kourier.yaml"
 kubectl patch configmap/config-network \
   --namespace knative-serving \
   --type merge \
   --patch '{"data":{"ingress.class":"kourier.ingress.networking.knative.dev"}}'
 
-kubectl apply -f "https://github.com/knative/eventing/releases/download/knative-v${OPERATOR_VERSION}/eventing-crds.yaml"
-kubectl apply -f "https://github.com/knative/eventing/releases/download/knative-v${OPERATOR_VERSION}/eventing-core.yaml"
+kubectl apply -f "https://github.com/knative/eventing/releases/download/knative-v${EVENTING_VERSION}/eventing-crds.yaml"
+kubectl apply -f "https://github.com/knative/eventing/releases/download/knative-v${EVENTING_VERSION}/eventing-core.yaml"
 
-kubectl apply -f "https://github.com/knative/eventing/releases/download/knative-v${OPERATOR_VERSION}/mt-channel-broker.yaml"
+kubectl apply -f "https://github.com/knative/eventing/releases/download/knative-v${EVENTING_VERSION}/mt-channel-broker.yaml"
 
 # Deploy Knative Operator
 kubectl apply -f "https://github.com/knative/operator/releases/download/knative-v${OPERATOR_VERSION}/operator.yaml" --wait


### PR DESCRIPTION
This PR modifies KNative install script to dynamically pull versions for EACH knative component (operator, serving, kourier and eventing).

Components might have different versions at runtime, for example here are versions for all 4 components (unlabelled, but you get the idea):
<img width="97" height="98" alt="image" src="https://github.com/user-attachments/assets/38180dd9-efb3-4eb9-b54a-5cf5897794ec" />

Tested on prod:
<img width="874" height="86" alt="image" src="https://github.com/user-attachments/assets/05da9fef-b298-4452-a623-a0a503e8a7b2" />
<img width="753" height="351" alt="image" src="https://github.com/user-attachments/assets/90e76010-32ee-428d-b014-7c93be4d6af4" />
