### PR TITLE
bump VictoriaMetrics Cluster components, vmagent and operator to the latest versions

### DIFF
--- a/stacks/victoria-metrics-cluster/README.md
+++ b/stacks/victoria-metrics-cluster/README.md
@@ -34,9 +34,9 @@ across nodes to ensure availability.
 
 | Package  | Version | License |
 | ------------- | ------------- | ------------- |
-| VictoriaMetrics Cluster  | [1.103.0](hhttps://docs.victoriametrics.com/changelog/#v11030)  | Apache 2.0  |
-| vmagent  | [1.103.0](https://docs.victoriametrics.com/changelog/#v11030)  | Apache 2.0  |
-| vmoperator  | [0.48.3](https://docs.victoriametrics.com/operator/changelog/#v0483---29-sep-2024)  | Apache 2.0  |
+| VictoriaMetrics Cluster  | [1.133.0](https://docs.victoriametrics.com/victoriametrics/changelog/#v11330)  | Apache 2.0  |
+| vmagent  | [1.133.0](https://docs.victoriametrics.com/victoriametrics/changelog/#v11330)  | Apache 2.0  |
+| vmoperator  | [0.66.1](https://docs.victoriametrics.com/operator/changelog/#v0661)  | Apache 2.0  |
 
 ## Getting started after deploying VictoriaMetrics Cluster
 
@@ -89,6 +89,6 @@ Then open in browser `http://127.0.0.1:8481/select/0/vmui/` , enter `vm_app_upti
 ## For further documentation visit:
 
 - [https://docs.victoriametrics.com/Cluster-VictoriaMetrics.html#cluster-setup](https://docs.victoriametrics.com/Cluster-VictoriaMetrics.html#cluster-setup)
-- [https://docs.victoriametrics.com/guides](https://docs.victoriametrics.com/guides)
+- [https://docs.victoriametrics.com/guides](https://docs.victoriametrics.com/guides/)
 - [https://github.com/VictoriaMetrics/helm-charts](https://github.com/VictoriaMetrics/helm-charts)
 - [https://docs.victoriametrics.com/Articles.html](https://docs.victoriametrics.com/Articles.html)

--- a/stacks/victoria-metrics-cluster/yaml/vmagent.yaml
+++ b/stacks/victoria-metrics-cluster/yaml/vmagent.yaml
@@ -7,6 +7,6 @@ spec:
   replicaCount: 1
   image:
     repository: victoriametrics/vmagent
-    tag: v1.103.0
+    tag: v1.133.0
   remoteWrite:
     - url: "http://vminsert-vmcluster.default.svc.cluster.local:8480/insert/0/prometheus/"

--- a/stacks/victoria-metrics-cluster/yaml/vmcluster.yaml
+++ b/stacks/victoria-metrics-cluster/yaml/vmcluster.yaml
@@ -8,14 +8,14 @@ spec:
       replicaCount: 2
       image:
         repository: victoriametrics/vmstorage
-        tag: v1.103.0-cluster
+        tag: v1.133.0-cluster
   vmselect:
       replicaCount: 2
       image:
         repository: victoriametrics/vmselect
-        tag: v1.103.0-cluster
+        tag: v1.133.0-cluster
   vminsert:
       replicaCount: 2
       image:
         repository: victoriametrics/vminsert
-        tag: v1.103.0-cluster
+        tag: v1.133.0-cluster


### PR DESCRIPTION
## BACKGROUND
* Product version update

-----------------------------------------------------------------------

## Changes
* README.md: update version of VictoriaMetrics Cluster, vmagent, operator to the latest versions
* bump [vmagent](https://docs.victoriametrics.com/victoriametrics/vmagent/) version to the latest [v1.133.0](https://docs.victoriametrics.com/victoriametrics/changelog/#v11330)
* bump version of [VictoriaMetrics Cluster](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/) to the latest [v1.133.0](https://docs.victoriametrics.com/victoriametrics/changelog/#v11330)
* bump VictoriaMetrics [operator](https://docs.victoriametrics.com/operator/) to the latest [v0.66.1](https://docs.victoriametrics.com/operator/changelog/#v0661)
------------------------------------------------------------------------

Reviewer: @marketplace-eng


-----------------------------------------------------------------------

## Checklist
- [x] review the [contributing doc](https://github.com/digitalocean/marketplace-kubernetes/blob/master/CONTRIBUTING.md) with steps for both adding or updating your application (if applicable)
------------------------------------------------------------------------

Reviewer: @marketplace-eng
