### PR TITLE
Make Kube State Metrics publicly accessible

### DIFF
--- a/stacks/kube-state-metrics/deploy.sh
+++ b/stacks/kube-state-metrics/deploy.sh
@@ -13,7 +13,7 @@ helm repo update > /dev/null
 ################################################################################
 STACK="kube-state-metrics"
 CHART="prometheus-community/kube-state-metrics"
-CHART_VERSION="6.3.0"
+CHART_VERSION="7.1.0"
 NAMESPACE="kube-state-metrics"
 
 if [ -z "${MP_KUBERNETES}" ]; then
@@ -32,6 +32,3 @@ helm upgrade "$STACK" "$CHART" \
   --values "$values" \
   --version "$CHART_VERSION" \
   --wait
-
-### ARTHUR'S NOTE: USING LATEST VERSION RESULTED IN EXTERNAL IP MISCONFIGURATION.
-### SERVICE STARTED UP BUT WAS NOT REACHABLE

--- a/stacks/kube-state-metrics/values.yml
+++ b/stacks/kube-state-metrics/values.yml
@@ -1,5 +1,9 @@
-# bitnami/kube-state-metrics
+# prometheus-community/kube-state-metrics
 
 global:
   labels:
     app.kubernetes.io/installed-by: digitalocean-marketplace
+
+service:
+  type: LoadBalancer
+  port: 8080


### PR DESCRIPTION

## BACKGROUND
* Using latest version of Kube State Metrics K8s 1-Click results in misconfiguration of external IP which means the 1-Click is not available publicly. This happens because the prometheus-community/kube-state-metrics chart defaults to `service.type: ClusterIP`, which only provides internal cluster access without an external IP.



-----------------------------------------------------------------------

## Changes
* Updated values.yaml with the correct service configuration
* Updated the app to the latest version

-----------------------------------------------------------------------

## Checklist
- [x] review the [contributing doc](https://github.com/digitalocean/marketplace-kubernetes/blob/master/CONTRIBUTING.md) with steps for both adding or updating your application (if applicable)
------------------------------------------------------------------------

Reviewer: @marketplace-eng
