### PR TITLE
Add Defensia Agent 1-Click App

### DIFF
--- a/stacks/defensia-agent/deploy.sh
+++ b/stacks/defensia-agent/deploy.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+set -e
+
+################################################################################
+# chart
+################################################################################
+STACK="defensia-agent"
+HELM_CHART_URL="oci://ghcr.io/defensia/charts/defensia-agent"
+NAMESPACE="defensia"
+
+if [ -z "${MP_KUBERNETES}" ]; then
+  # use local version of values.yml
+  ROOT_DIR=$(git rev-parse --show-toplevel)
+  values="$ROOT_DIR/stacks/defensia-agent/values.yml"
+else
+  # use github hosted master version of values.yml
+  values="https://raw.githubusercontent.com/digitalocean/marketplace-kubernetes/master/stacks/defensia-agent/values.yml"
+fi
+
+helm upgrade "$STACK" "$HELM_CHART_URL" \
+  --atomic \
+  --create-namespace \
+  --install \
+  --timeout 5m0s \
+  --namespace "$NAMESPACE" \
+  --values "$values"

--- a/stacks/defensia-agent/uninstall.sh
+++ b/stacks/defensia-agent/uninstall.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+set -e
+
+################################################################################
+# chart
+################################################################################
+STACK="defensia-agent"
+NAMESPACE="defensia"
+
+helm uninstall "$STACK" \
+  --namespace "$NAMESPACE"
+kubectl delete --ignore-not-found=true namespace "$NAMESPACE"

--- a/stacks/defensia-agent/upgrade.sh
+++ b/stacks/defensia-agent/upgrade.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+set -e
+
+################################################################################
+# chart
+################################################################################
+STACK="defensia-agent"
+HELM_CHART_URL="oci://ghcr.io/defensia/charts/defensia-agent"
+NAMESPACE="defensia"
+
+if [ -z "${MP_KUBERNETES}" ]; then
+  ROOT_DIR=$(git rev-parse --show-toplevel)
+  values="$ROOT_DIR/stacks/defensia-agent/values.yml"
+else
+  values="https://raw.githubusercontent.com/digitalocean/marketplace-kubernetes/master/stacks/defensia-agent/values.yml"
+fi
+
+helm upgrade "$STACK" "$HELM_CHART_URL" \
+  --namespace "$NAMESPACE" \
+  --values "$values"

--- a/stacks/defensia-agent/values.yml
+++ b/stacks/defensia-agent/values.yml
@@ -1,0 +1,21 @@
+## Defensia Agent — DigitalOcean Kubernetes 1-Click values
+## Ref: https://github.com/defensia/agent/tree/main/charts/defensia-agent
+
+# Set your install token from https://defensia.cloud/dashboard
+token: ""
+
+image:
+  repository: ghcr.io/defensia/agent
+  pullPolicy: IfNotPresent
+
+resources:
+  limits:
+    cpu: 200m
+    memory: 128Mi
+  requests:
+    cpu: 50m
+    memory: 64Mi
+
+# Run on all nodes including control-plane
+tolerations:
+  - operator: Exists


### PR DESCRIPTION
## Defensia Agent — Kubernetes 1-Click App

### What is Defensia?

Defensia is a lightweight security agent for Linux servers that provides real-time attack detection and automatic blocking. It deploys as a DaemonSet (one agent per node) and protects against SSH brute force, web attacks (WAF with 15+ OWASP types), bot abuse, and more — all managed from a centralized dashboard at [defensia.cloud](https://defensia.cloud).

### Deployment method

- **Helm chart (OCI):** `oci://ghcr.io/defensia/charts/defensia-agent`
- **Image:** `ghcr.io/defensia/agent` (multi-arch: amd64 + arm64, ~40MB)
- **Namespace:** `defensia`
- **DaemonSet** with tolerations for all nodes (including control-plane)

### Links

- Website: https://defensia.cloud
- GitHub: https://github.com/defensia/agent
- Helm chart: https://artifacthub.io/packages/helm/defensia-agent/defensia-agent
- Docker Hub: https://hub.docker.com/r/defensiacloud/agent
- DigitalOcean Droplet 1-Click (already approved): https://marketplace.digitalocean.com/apps/defensia-agent

### Features

- SSH brute force detection (15 patterns)
- Web Application Firewall (SQLi, XSS, path traversal, RCE, 15+ types)
- Bot management (70+ fingerprints, allow/log/block policies)
- Docker container monitoring + label-based autoconf
- Server metrics (CPU, memory, disk, network)
- CVE vulnerability scanning (NVD + EPSS + CISA KEV)
- Geo-blocking, threat intelligence, cross-server ban propagation
- Real-time dashboard with WebSocket updates

### Testing

```bash
helm install defensia-agent oci://ghcr.io/defensia/charts/defensia-agent \
  --create-namespace --namespace defensia \
  --set token=<TOKEN_FROM_DEFENSIA_CLOUD>
```

Verified on DOKS 1.29+ with 1-3 node clusters.