### PR TITLE
Add Defensia Agent — server security DaemonSet

### DIFF
--- a/stacks/defensia-agent/deploy.sh
+++ b/stacks/defensia-agent/deploy.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+set -e
+
+################################################################################
+# DigitalOcean Marketplace Kubernetes — Defensia Agent
+# Deploys the Defensia security agent as a DaemonSet via Helm chart
+################################################################################
+
+STACK_NAME="defensia-agent"
+CHART_VERSION="0.4.1"
+NAMESPACE="defensia-system"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+if [ -z "${MP_KUBERNETES}" ]; then
+  # Local/dev mode — use values file next to this script
+  VALUES_FILE="${SCRIPT_DIR}/values.yml"
+else
+  # Marketplace mode — fetch values from GitHub
+  VALUES_FILE="https://raw.githubusercontent.com/digitalocean/marketplace-kubernetes/master/stacks/${STACK_NAME}/values.yml"
+fi
+
+helm upgrade "$STACK_NAME" oci://ghcr.io/defensia/charts/defensia-agent \
+  --rollback-on-failure \
+  --create-namespace \
+  --install \
+  --timeout 8m0s \
+  --namespace "$NAMESPACE" \
+  --values "$VALUES_FILE" \
+  --version "$CHART_VERSION"

--- a/stacks/defensia-agent/uninstall.sh
+++ b/stacks/defensia-agent/uninstall.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -e
+
+################################################################################
+# DigitalOcean Marketplace Kubernetes — Defensia Agent (Uninstall)
+################################################################################
+
+STACK_NAME="defensia-agent"
+NAMESPACE="defensia-system"
+
+helm uninstall "$STACK_NAME" --namespace "$NAMESPACE"
+kubectl delete namespace "$NAMESPACE" --ignore-not-found=true

--- a/stacks/defensia-agent/upgrade.sh
+++ b/stacks/defensia-agent/upgrade.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+set -e
+
+################################################################################
+# DigitalOcean Marketplace Kubernetes — Defensia Agent (Upgrade)
+################################################################################
+
+STACK_NAME="defensia-agent"
+CHART_VERSION="0.4.1"
+NAMESPACE="defensia-system"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+if [ -z "${MP_KUBERNETES}" ]; then
+  VALUES_FILE="${SCRIPT_DIR}/values.yml"
+else
+  VALUES_FILE="https://raw.githubusercontent.com/digitalocean/marketplace-kubernetes/master/stacks/${STACK_NAME}/values.yml"
+fi
+
+helm upgrade "$STACK_NAME" oci://ghcr.io/defensia/charts/defensia-agent \
+  --rollback-on-failure \
+  --install \
+  --timeout 8m0s \
+  --namespace "$NAMESPACE" \
+  --values "$VALUES_FILE" \
+  --version "$CHART_VERSION"

--- a/stacks/defensia-agent/values.yml
+++ b/stacks/defensia-agent/values.yml
@@ -1,0 +1,25 @@
+# Defensia Agent — DigitalOcean Kubernetes Marketplace defaults
+#
+# After deployment, set your Organization API Key:
+#   helm upgrade defensia-agent oci://ghcr.io/defensia/charts/defensia-agent \
+#     --set apiKey=YOUR_API_KEY -n defensia-system
+
+# Required: generate at defensia.cloud → Settings → Organization → API Keys
+apiKey: ""
+
+serverUrl: "https://defensia.cloud"
+
+# Auto-detected from kubeconfig if empty
+clusterName: ""
+
+resources:
+  limits:
+    cpu: 100m
+    memory: 128Mi
+  requests:
+    cpu: 50m
+    memory: 64Mi
+
+# Run on all nodes including control-plane
+tolerations:
+  - operator: Exists


### PR DESCRIPTION
## Summary

Adds **Defensia Agent** as a Kubernetes 1-Click App. Defensia is a lightweight Go security agent that deploys as a DaemonSet on every cluster node, monitoring ingress logs, SSH auth, and pod events to detect and block attacks automatically.

## What it does

- **Web Application Firewall** — 15 OWASP attack types (SQLi, XSS, SSRF, RCE, path traversal, scanner detection, and more)
- **SSH brute force detection** — 15 patterns with progressive ban escalation (24h → 7d → 30d → permanent)
- **Bot management** — 70+ bot fingerprints with allow/log/block policies per cluster
- **Kubernetes monitoring** — pod lifecycle events, API audit log analysis, ingress host discovery
- **Real-time dashboard** at [defensia.cloud](https://defensia.cloud) with alerts (Email, Slack, Discord)

## Chart details

- **Chart:** `oci://ghcr.io/defensia/charts/defensia-agent` (v0.4.1)
- **Deploys:** DaemonSet (1 pod per node, including control-plane), ServiceAccount, ClusterRole, ClusterRoleBinding
- **Resources:** 50m CPU / 64Mi RAM request, 100m / 128Mi limit
- **License:** MIT ([github.com/defensia/agent](https://github.com/defensia/agent))
- **Artifact Hub:** [artifacthub.io/packages/helm/defensia/defensia-agent](https://artifacthub.io/packages/helm/defensia/defensia-agent)
- **Images signed** with Cosign, Helm chart with GPG provenance

## Tested on

- DigitalOcean Kubernetes (DOKS), 2-node cluster, Frankfurt (fra1), K8s v1.35.1
- `deploy.sh` — DaemonSet created, pods running, agent executes and attempts registration
- `upgrade.sh` — Revision 1→2 successful
- `uninstall.sh` — Release + namespace fully removed, no orphaned resources

## Pricing

- Free tier: 1 node with full protection
- Pro: $9.90/node/month (unlimited nodes, alerts, vulnerability scanning, compliance reports)