### PR TITLE
Update triliovault to last requirements

### DIFF
--- a/stacks/triliovault-operator/deploy.sh
+++ b/stacks/triliovault-operator/deploy.sh
@@ -22,6 +22,12 @@ INSTALL_TVM=true
 TVK_HOSTNAME="tvk.doks.com"
 TVK_INSTANCE_NAME="tvk-instance-digital-ocean"
 INGRESS_SERVICE_TYPE="NodePort"
+WEBHOOK_ABSENT_GRACE_TRIES="${TVK_WEBHOOK_ABSENT_GRACE_TRIES:-20}"
+WEBHOOK_READY_TIMEOUT_TRIES="${TVK_WEBHOOK_READY_TIMEOUT_TRIES:-100}"
+WEBHOOK_WAIT_INTERVAL_SECONDS="${TVK_WEBHOOK_WAIT_INTERVAL_SECONDS:-3}"
+LICENSE_WAIT_TIMEOUT_TRIES="${TVK_LICENSE_WAIT_TIMEOUT_TRIES:-120}"
+LICENSE_WAIT_INTERVAL_SECONDS="${TVK_LICENSE_WAIT_INTERVAL_SECONDS:-3}"
+LICENSE_JOB_NAME="${TVK_LICENSE_JOB_NAME:-tvk-license-do}"
 
 # Install triliovault operator and triliovault manager
 echo "Installing TrilioVault operator and TrilioVault Manager with one-click install functionality"
@@ -39,7 +45,7 @@ else
 fi
 
 helm upgrade "$STACK" "$CHART" \
-  --atomic \
+  --rollback-on-failure \
   --create-namespace \
   --install \
   --namespace "$NAMESPACE" \
@@ -56,15 +62,59 @@ if [ "$retcode" -ne 0 ]; then
   return 1
 fi
 
-until (kubectl get pods --namespace "$NAMESPACE" -l "release=triliovault-operator" 2>/dev/null | grep Running); do sleep 3; done
+until (kubectl get pods --namespace "$NAMESPACE" -l "release=triliovault-operator" 2>/dev/null | grep Running); do
+  echo "Waiting for TrilioVault operator (release=triliovault-operator)..."
+  kubectl get pods --namespace "$NAMESPACE" -l "release=triliovault-operator" 2>/dev/null || true
+  sleep 3
+done
 
-until (kubectl get pods --namespace "$NAMESPACE" -l "triliovault.trilio.io/owner=triliovault-manager" 2>/dev/null | grep Running); do sleep 3; done
-until (kubectl get pods --namespace "$NAMESPACE" -l app=k8s-triliovault-exporter 2>/dev/null | grep 1/1); do sleep 3; done
-until (kubectl get pods --namespace "$NAMESPACE" -l "app.kubernetes.io/name=k8s-triliovault-ingress-nginx" 2>/dev/null | grep 1/1); do sleep 3; done
-until (kubectl get pods --namespace "$NAMESPACE" -l app=k8s-triliovault-web 2>/dev/null | grep 1/1); do sleep 3; done
-until (kubectl get pods --namespace "$NAMESPACE" -l app=k8s-triliovault-web-backend 2>/dev/null | grep 1/1); do sleep 3; done
-until (kubectl get pods --namespace "$NAMESPACE" -l app=k8s-triliovault-control-plane 2>/dev/null | grep 2/2); do sleep 3; done
-until (kubectl get pods --namespace "$NAMESPACE" -l app=k8s-triliovault-admission-webhook 2>/dev/null | grep 1/1); do sleep 3; done
+until (kubectl get pods --namespace "$NAMESPACE" -l "triliovault.trilio.io/owner=triliovault-manager" 2>/dev/null | grep Running); do
+  echo "Waiting for TrilioVault Manager workloads..."
+  kubectl get pods --namespace "$NAMESPACE" -l "triliovault.trilio.io/owner=triliovault-manager" 2>/dev/null || true
+  sleep 3
+done
+until (kubectl get pods --namespace "$NAMESPACE" -l app=k8s-triliovault-exporter 2>/dev/null | grep 1/1); do
+  echo "Waiting for k8s-triliovault-exporter..."
+  kubectl get pods --namespace "$NAMESPACE" -l app=k8s-triliovault-exporter 2>/dev/null || true
+  sleep 3
+done
+until (kubectl get pods --namespace "$NAMESPACE" -l "app.kubernetes.io/name=k8s-triliovault-ingress-nginx" 2>/dev/null | grep 1/1); do
+  echo "Waiting for k8s-triliovault-ingress-nginx..."
+  kubectl get pods --namespace "$NAMESPACE" -l "app.kubernetes.io/name=k8s-triliovault-ingress-nginx" 2>/dev/null || true
+  sleep 3
+done
+until (kubectl get pods --namespace "$NAMESPACE" -l app=k8s-triliovault-web 2>/dev/null | grep 1/1); do
+  echo "Waiting for k8s-triliovault-web..."
+  kubectl get pods --namespace "$NAMESPACE" -l app=k8s-triliovault-web 2>/dev/null || true
+  sleep 3
+done
+until (kubectl get pods --namespace "$NAMESPACE" -l app=k8s-triliovault-web-backend 2>/dev/null | grep 1/1); do
+  echo "Waiting for k8s-triliovault-web-backend..."
+  kubectl get pods --namespace "$NAMESPACE" -l app=k8s-triliovault-web-backend 2>/dev/null || true
+  sleep 3
+done
+# READY n/n when all containers are ready (1/1 or 2/2 depending on chart version).
+until (kubectl get pods --namespace "$NAMESPACE" -l app=k8s-triliovault-control-plane --no-headers 2>/dev/null | awk '$2 ~ "^[0-9]+/[0-9]+$" { n = split($2, a, "/"); if (n == 2 && a[1] == a[2] && a[1] > 0) found = 1 } END { exit found ? 0 : 1 }'); do
+  echo "Waiting for k8s-triliovault-control-plane..."
+  kubectl get pods --namespace "$NAMESPACE" -l app=k8s-triliovault-control-plane 2>/dev/null || true
+  sleep 3
+done
+webhook_wait_tries=0
+until (kubectl get pods --namespace "$NAMESPACE" -l app=k8s-triliovault-admission-webhook --no-headers 2>/dev/null | awk '$2 ~ "^[0-9]+/[0-9]+$" { n = split($2, a, "/"); if (n == 2 && a[1] == a[2] && a[1] > 0) found = 1 } END { exit found ? 0 : 1 }'); do
+  webhook_wait_tries=$((webhook_wait_tries + 1))
+  echo "Waiting for k8s-triliovault-admission-webhook..."
+  webhook_pods="$(kubectl get pods --namespace "$NAMESPACE" -l app=k8s-triliovault-admission-webhook --no-headers 2>/dev/null || true)"
+  if [ -z "$webhook_pods" ] && [ "$webhook_wait_tries" -ge "$WEBHOOK_ABSENT_GRACE_TRIES" ]; then
+    echo "k8s-triliovault-admission-webhook pods not found after grace period; continuing without this optional wait."
+    break
+  fi
+  kubectl get pods --namespace "$NAMESPACE" -l app=k8s-triliovault-admission-webhook 2>/dev/null || true
+  if [ "$webhook_wait_tries" -ge "$WEBHOOK_READY_TIMEOUT_TRIES" ]; then
+    echo "Timed out waiting for k8s-triliovault-admission-webhook to become ready."
+    exit 1
+  fi
+  sleep "$WEBHOOK_WAIT_INTERVAL_SECONDS"
+done
 
 ################################################################################
 # Enable TVK Management Console using NodePort
@@ -120,16 +170,28 @@ install_license () {
   
   sleep 5
   echo "Verifying license generation job..."
-  until (kubectl get pods --namespace "$NAMESPACE" -l "job-name=tvk-license-do" 2>/dev/null | grep Completed); do sleep 3; done
+  license_wait_tries=0
+  until (kubectl get pods --namespace "$NAMESPACE" -l "job-name=$LICENSE_JOB_NAME" 2>/dev/null | grep Completed >/dev/null) || [ "$(kubectl get license trilio-license --namespace "$NAMESPACE" -o 'jsonpath={.status.status}' 2>/dev/null || true)" = "Active" ]; do
+    license_wait_tries=$((license_wait_tries + 1))
+    echo "Waiting for license job '$LICENSE_JOB_NAME' (or Active license status)..."
+    kubectl get pods --namespace "$NAMESPACE" -l "job-name=$LICENSE_JOB_NAME" 2>/dev/null || true
+    if [ "$license_wait_tries" -ge "$LICENSE_WAIT_TIMEOUT_TRIES" ]; then
+      echo "Timed out waiting for license generation."
+      echo "Diagnostic jobs that might be related to license:"
+      kubectl get jobs --namespace "$NAMESPACE" 2>/dev/null | awk 'NR==1 || /[Ll]icense|tvk/' || true
+      return 1
+    fi
+    sleep "$LICENSE_WAIT_INTERVAL_SECONDS"
+  done
 
   echo "Verifying license status on namespace $NAMESPACE ..."
-  lic_status=$(kubectl get license trilio-license --namespace $NAMESPACE -o 'jsonpath={.status.status}')
+  lic_status=$(kubectl get license trilio-license --namespace "$NAMESPACE" -o 'jsonpath={.status.status}')
   exp_status="Active"
 
   if [ "$lic_status" != "$exp_status" ] ; then
-    echo "License installation failed, license status is '$lic_status'"
+    printf 'License installation failed, license status is %s\n' "$lic_status"
   else
-    echo "License is installed successfully, license status is '$lic_status'"
+    printf 'License is installed successfully, license status is %s\n' "$lic_status"
   fi
 
 }

--- a/stacks/triliovault-operator/upgrade.sh
+++ b/stacks/triliovault-operator/upgrade.sh
@@ -18,6 +18,9 @@ LATEST="$(helm show chart triliovault-operator/k8s-triliovault-operator | grep a
 echo "Upgrading TVK to latest version: $LATEST"
 CHART_VERSION=$LATEST
 NAMESPACE="trilio-system"
+WEBHOOK_ABSENT_GRACE_TRIES="${TVK_WEBHOOK_ABSENT_GRACE_TRIES:-20}"
+WEBHOOK_READY_TIMEOUT_TRIES="${TVK_WEBHOOK_READY_TIMEOUT_TRIES:-100}"
+WEBHOOK_WAIT_INTERVAL_SECONDS="${TVK_WEBHOOK_WAIT_INTERVAL_SECONDS:-3}"
 
 # Upgrade triliovault operator
 echo "Upgrading Triliovault operator..."
@@ -37,7 +40,7 @@ else
 fi
 
 helm upgrade "$STACK" "$CHART" \
-  --atomic \
+  --rollback-on-failure \
   --create-namespace \
   --install \
   --namespace "$NAMESPACE" \
@@ -50,7 +53,11 @@ if [ "$retcode" -ne 0 ]; then
   return 1
 fi
 
-until (kubectl get pods --namespace "$NAMESPACE" -l "release=triliovault-operator" 2>/dev/null | grep Running); do sleep 3; done
+until (kubectl get pods --namespace "$NAMESPACE" -l "release=triliovault-operator" 2>/dev/null | grep Running); do
+  echo "Waiting for TrilioVault operator (release=triliovault-operator)..."
+  kubectl get pods --namespace "$NAMESPACE" -l "release=triliovault-operator" 2>/dev/null || true
+  sleep 3
+done
 
 ################################################################################
 # TVK Manager Upgrade
@@ -71,13 +78,52 @@ install_tvm () {
     return 1
   fi
 
-  until (kubectl get pods --namespace "$NAMESPACE" -l "triliovault.trilio.io/owner=triliovault-manager" 2>/dev/null | grep Running); do sleep 3; done
-  until (kubectl get pods --namespace "$NAMESPACE" -l app=k8s-triliovault-exporter 2>/dev/null | grep 1/1); do sleep 3; done
-  until (kubectl get pods --namespace "$NAMESPACE" -l "app.kubernetes.io/name=k8s-triliovault-ingress-nginx" 2>/dev/null | grep 1/1); do sleep 3; done
-  until (kubectl get pods --namespace "$NAMESPACE" -l app=k8s-triliovault-web 2>/dev/null | grep 1/1); do sleep 3; done
-  until (kubectl get pods --namespace "$NAMESPACE" -l app=k8s-triliovault-web-backend 2>/dev/null | grep 1/1); do sleep 3; done
-  until (kubectl get pods --namespace "$NAMESPACE" -l app=k8s-triliovault-control-plane 2>/dev/null | grep 2/2); do sleep 3; done
-  until (kubectl get pods --namespace "$NAMESPACE" -l app=k8s-triliovault-admission-webhook 2>/dev/null | grep 1/1); do sleep 3; done
+  until (kubectl get pods --namespace "$NAMESPACE" -l "triliovault.trilio.io/owner=triliovault-manager" 2>/dev/null | grep Running); do
+    echo "Waiting for TrilioVault Manager workloads..."
+    kubectl get pods --namespace "$NAMESPACE" -l "triliovault.trilio.io/owner=triliovault-manager" 2>/dev/null || true
+    sleep 3
+  done
+  until (kubectl get pods --namespace "$NAMESPACE" -l app=k8s-triliovault-exporter 2>/dev/null | grep 1/1); do
+    echo "Waiting for k8s-triliovault-exporter..."
+    kubectl get pods --namespace "$NAMESPACE" -l app=k8s-triliovault-exporter 2>/dev/null || true
+    sleep 3
+  done
+  until (kubectl get pods --namespace "$NAMESPACE" -l "app.kubernetes.io/name=k8s-triliovault-ingress-nginx" 2>/dev/null | grep 1/1); do
+    echo "Waiting for k8s-triliovault-ingress-nginx..."
+    kubectl get pods --namespace "$NAMESPACE" -l "app.kubernetes.io/name=k8s-triliovault-ingress-nginx" 2>/dev/null || true
+    sleep 3
+  done
+  until (kubectl get pods --namespace "$NAMESPACE" -l app=k8s-triliovault-web 2>/dev/null | grep 1/1); do
+    echo "Waiting for k8s-triliovault-web..."
+    kubectl get pods --namespace "$NAMESPACE" -l app=k8s-triliovault-web 2>/dev/null || true
+    sleep 3
+  done
+  until (kubectl get pods --namespace "$NAMESPACE" -l app=k8s-triliovault-web-backend 2>/dev/null | grep 1/1); do
+    echo "Waiting for k8s-triliovault-web-backend..."
+    kubectl get pods --namespace "$NAMESPACE" -l app=k8s-triliovault-web-backend 2>/dev/null || true
+    sleep 3
+  done
+  until (kubectl get pods --namespace "$NAMESPACE" -l app=k8s-triliovault-control-plane --no-headers 2>/dev/null | awk '$2 ~ "^[0-9]+/[0-9]+$" { n = split($2, a, "/"); if (n == 2 && a[1] == a[2] && a[1] > 0) found = 1 } END { exit found ? 0 : 1 }'); do
+    echo "Waiting for k8s-triliovault-control-plane..."
+    kubectl get pods --namespace "$NAMESPACE" -l app=k8s-triliovault-control-plane 2>/dev/null || true
+    sleep 3
+  done
+  webhook_wait_tries=0
+  until (kubectl get pods --namespace "$NAMESPACE" -l app=k8s-triliovault-admission-webhook --no-headers 2>/dev/null | awk '$2 ~ "^[0-9]+/[0-9]+$" { n = split($2, a, "/"); if (n == 2 && a[1] == a[2] && a[1] > 0) found = 1 } END { exit found ? 0 : 1 }'); do
+    webhook_wait_tries=$((webhook_wait_tries + 1))
+    echo "Waiting for k8s-triliovault-admission-webhook..."
+    webhook_pods="$(kubectl get pods --namespace "$NAMESPACE" -l app=k8s-triliovault-admission-webhook --no-headers 2>/dev/null || true)"
+    if [ -z "$webhook_pods" ] && [ "$webhook_wait_tries" -ge "$WEBHOOK_ABSENT_GRACE_TRIES" ]; then
+      echo "k8s-triliovault-admission-webhook pods not found after grace period; continuing without this optional wait."
+      break
+    fi
+    kubectl get pods --namespace "$NAMESPACE" -l app=k8s-triliovault-admission-webhook 2>/dev/null || true
+    if [ "$webhook_wait_tries" -ge "$WEBHOOK_READY_TIMEOUT_TRIES" ]; then
+      echo "Timed out waiting for k8s-triliovault-admission-webhook to become ready."
+      return 1
+    fi
+    sleep "$WEBHOOK_WAIT_INTERVAL_SECONDS"
+  done
 }
 
 ################################################################################


### PR DESCRIPTION
## BACKGROUND

This PR updates the TrilioVault Operator install/upgrade scripts to remove deprecated Helm flags and make readiness checks more reliable across newer TVK chart versions.

Recent TVK chart behavior differs from the original script assumptions (e.g., 1/1 instead of 2/2, admission webhook pod may be absent/renamed depending on chart/config). The old logic could hang indefinitely even when install was effectively healthy. This PR makes waits version-tolerant, configurable, and fail-fast with diagnostics.

## Changes
* Replaced deprecated Helm flag:
  * --atomic -> --rollback-on-failure
* Updated post-install readiness checks in:
 * stacks/triliovault-operator/deploy.sh
 * stacks/triliovault-operator/upgrade.sh
* Kept kubectl get pods-based progress output (so users still see READY/STATUS/AGE) while fixing blocking conditions:
  * control-plane wait now accepts any fully-ready n/n (not hardcoded 2/2)
  * admission-webhook wait no longer loops forever if the pod is absent
* Added configurable wait knobs via env vars:
 * TVK_WEBHOOK_ABSENT_GRACE_TRIES
 * TVK_WEBHOOK_READY_TIMEOUT_TRIES
 * TVK_WEBHOOK_WAIT_INTERVAL_SECONDS
 * TVK_LICENSE_WAIT_TIMEOUT_TRIES (deploy only)
 * TVK_LICENSE_WAIT_INTERVAL_SECONDS (deploy only)
 * TVK_LICENSE_JOB_NAME (deploy only)
* Hardened license verification in deploy.sh:
 * stop infinite waiting for tvk-license-do
 * accept success when license status becomes Active
 * emit diagnostics and fail explicitly on timeout
* Small shell robustness fixes:
 * quote namespace usage in license status query
 * use printf for license status messages
## Checklist
- [ ] review the [contributing doc](https://github.com/digitalocean/marketplace-kubernetes/blob/master/CONTRIBUTING.md) with steps for both adding or updating your application (if applicable)
------------------------------------------------------------------------

Reviewer: @marketplace-eng
