### PR TITLE
Add rstream operator

### DIFF
--- a/stacks/rstream-operator/deploy.sh
+++ b/stacks/rstream-operator/deploy.sh
@@ -4,7 +4,7 @@ set -eu
 
 STACK="rstream-operator"
 CHART="oci://ghcr.io/rstreamlabs/rstream-operator"
-CHART_VERSION="0.5.1"
+CHART_VERSION="0.5.2"
 NAMESPACE="rstream-system"
 
 if [ -z "${MP_KUBERNETES:-}" ]; then

--- a/stacks/rstream-operator/deploy.sh
+++ b/stacks/rstream-operator/deploy.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+set -eu
+
+STACK="rstream-operator"
+CHART="oci://ghcr.io/rstreamlabs/rstream-operator"
+CHART_VERSION="0.5.1"
+NAMESPACE="rstream-system"
+
+if [ -z "${MP_KUBERNETES:-}" ]; then
+  ROOT_DIR=$(git -C "$(dirname "$0")" rev-parse --show-toplevel)
+  values="$ROOT_DIR/stacks/rstream-operator/values.yml"
+else
+  values="https://raw.githubusercontent.com/digitalocean/marketplace-kubernetes/master/stacks/rstream-operator/values.yml"
+fi
+
+helm upgrade "$STACK" "$CHART" \
+  --atomic \
+  --create-namespace \
+  --install \
+  --timeout 8m0s \
+  --namespace "$NAMESPACE" \
+  --values "$values" \
+  --version "$CHART_VERSION"

--- a/stacks/rstream-operator/uninstall.sh
+++ b/stacks/rstream-operator/uninstall.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+set -eu
+
+STACK="rstream-operator"
+NAMESPACE="rstream-system"
+
+helm uninstall "$STACK" --namespace "$NAMESPACE"
+kubectl delete --ignore-not-found=true namespace "$NAMESPACE"

--- a/stacks/rstream-operator/upgrade.sh
+++ b/stacks/rstream-operator/upgrade.sh
@@ -4,7 +4,7 @@ set -eu
 
 STACK="rstream-operator"
 CHART="oci://ghcr.io/rstreamlabs/rstream-operator"
-CHART_VERSION="0.5.1"
+CHART_VERSION="0.5.2"
 NAMESPACE="rstream-system"
 
 if [ -z "${MP_KUBERNETES:-}" ]; then

--- a/stacks/rstream-operator/upgrade.sh
+++ b/stacks/rstream-operator/upgrade.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+set -eu
+
+STACK="rstream-operator"
+CHART="oci://ghcr.io/rstreamlabs/rstream-operator"
+CHART_VERSION="0.5.1"
+NAMESPACE="rstream-system"
+
+if [ -z "${MP_KUBERNETES:-}" ]; then
+  ROOT_DIR=$(git -C "$(dirname "$0")" rev-parse --show-toplevel)
+  values="$ROOT_DIR/stacks/rstream-operator/values.yml"
+else
+  values="https://raw.githubusercontent.com/digitalocean/marketplace-kubernetes/master/stacks/rstream-operator/values.yml"
+fi
+
+helm upgrade "$STACK" "$CHART" \
+  --atomic \
+  --timeout 8m0s \
+  --namespace "$NAMESPACE" \
+  --values "$values" \
+  --version "$CHART_VERSION"

--- a/stacks/rstream-operator/values.yml
+++ b/stacks/rstream-operator/values.yml
@@ -1,0 +1,1 @@
+# rstream-operator


### PR DESCRIPTION
## BACKGROUND

Add rstream operator as a Kubernetes 1-Click App. The integration installs the existing upstream Helm chart directly from its public OCI package and does not copy or vendor the chart.

------------------------------------------------------------------------

## Changes

- add deploy, upgrade, and uninstall scripts for rstream operator
- pin the existing OCI Helm chart to version 0.5.2
- add the stack values file expected by the Marketplace
- preserve Helm-managed CRDs during uninstall to avoid deleting user resources

The submitted chart version passes anonymous OCI pull, Helm rendering with the submitted values, shell syntax, and ShellCheck validation. The deployment lifecycle was also tested on a clean local Kubernetes 1.36 cluster using the preceding chart version: deploy completed with the controller Ready, upgrade created a successful second Helm revision, and uninstall removed the release and namespace.

------------------------------------------------------------------------

## Checklist

- [x] Reviewed the contributing document and followed the required add-application steps.

------------------------------------------------------------------------

Reviewer: @marketplace-eng