### PR TITLE
Add Plane Commercial Kubernetes 1-Click App

### DIFF
--- a/stacks/plane/README.md
+++ b/stacks/plane/README.md
@@ -1,0 +1,204 @@
+# Description
+
+[Plane](https://plane.so/) is an open-source project and issue tracking tool for planning
+sprints, tracking cycles, and shipping products -- an alternative to Jira, Linear, and
+Asana that you run yourself.
+
+This 1-Click deploys **Plane Enterprise**, which includes a free tier with no license
+required to start. If you later purchase a commercial plan, you attach a license key to
+the same deployment -- there is no migration or reinstall involved. If you'd rather stay
+on the fully open-source edition indefinitely, deploy [plane-ce](https://github.com/makeplane/helm-charts/tree/main/charts/plane-ce)
+via `helm` directly instead.
+
+This 1-Click provisions everything Plane needs to run standalone on a fresh DOKS
+cluster, with no configuration required: a Traefik ingress controller, the API, web,
+space, admin and real-time collaboration services, background workers, and bundled
+Postgres, Valkey (Redis), RabbitMQ and MinIO -- all backed by DigitalOcean Block
+Storage. It's reachable immediately at a working URL with no DNS setup (see
+[Domain and access](#domain-and-access)).
+
+DigitalOcean's Kubernetes 1-Click flow runs `deploy.sh` with no way for you to supply
+values or environment variables, so this stack deliberately has no install-time
+configuration options. If you want to swap a bundled service for a DigitalOcean Managed
+Database/Spaces bucket, add TLS, or otherwise customize it, do that afterwards yourself
+with `helm upgrade` directly -- see [Customizing beyond this 1-click](#customizing-beyond-this-1-click).
+
+Thank you to all the contributors whose hard work makes Plane valuable for users.
+
+## Software included
+
+| Package         | Version | License                                                                  |
+| ---------------- | ------- | ------------------------------------------------------------------------ |
+| Plane Enterprise | v3.1.2  | [Plane Enterprise License](https://github.com/makeplane/plane-ee/blob/master/LICENSE.md) |
+| Traefik          | 3.x     | [MIT](https://github.com/traefik/traefik/blob/master/LICENSE.md)         |
+| PostgreSQL       | 15.7    | [PostgreSQL License](https://www.postgresql.org/about/licence/)          |
+| Valkey (Redis)   | 7.2.11  | [BSD 3-Clause](https://github.com/valkey-io/valkey/blob/unstable/COPYING) |
+| RabbitMQ         | 3.13.6  | [MPL 2.0](https://github.com/rabbitmq/rabbitmq-server/blob/main/LICENSE-MPL-RabbitMQ) |
+| MinIO            | latest  | [AGPL 3.0](https://github.com/minio/minio/blob/master/LICENSE)           |
+
+All of the above are always deployed by this stack, alongside Plane itself.
+
+## Resources
+
+This stack runs ~20 pods, including four stateful services with their own persistent
+volumes. **Minimum: a single 4 vCPU / 8GB RAM node.** For a production-sized deployment
+we recommend **3 nodes at 4 vCPU / 8GB RAM each**.
+
+This minimum isn't a rough guess -- on a 2 vCPU / 4GB node, the first-install database
+migration job alone (Postgres schema setup for a brand-new install) took **~30 minutes**
+before the API became reachable, with everything else contending for the same limited
+CPU. On 4 vCPU / 8GB it's substantially faster. If your cluster is smaller than this,
+`deploy.sh` will still complete, but expect a long, CPU-starved wait before Plane comes
+up on first install -- see [What to expect during install](#what-to-expect-during-install).
+
+See the [chart's configuration reference](https://github.com/makeplane/helm-charts/blob/main/charts/plane-enterprise/README.md)
+to right-size individual services (`services.<name>.cpuLimit` / `memoryLimit`) for your
+workload.
+
+# Getting Started
+
+### Getting Started with DigitalOcean Kubernetes
+
+As you get started with Kubernetes on DigitalOcean be sure to check out how to connect
+to your cluster using `kubectl` and `doctl`:
+https://www.digitalocean.com/docs/kubernetes/how-to/connect-to-cluster/
+
+Additional instructions are included in the DigitalOcean Kubernetes control panel:
+https://cloud.digitalocean.com/kubernetes/clusters/
+
+### What to expect during install
+
+Whether you installed from the DigitalOcean portal's Marketplace tab or ran `deploy.sh`
+yourself, there's no progress bar or "Plane is ready" notification -- Kubernetes 1-Click
+Apps don't surface one, and the portal doesn't hand you an access link the way a Droplet
+1-click would. You confirm it's up, and find its URL, with `kubectl` (see below).
+
+What happens, in order, after `deploy.sh` runs:
+
+1. Traefik is installed and gets a DigitalOcean LoadBalancer IP (~1-2 minutes).
+2. Postgres, Valkey, RabbitMQ and MinIO come up, and Plane's database migration Job
+   runs against a brand-new database. **This is the long pole.** On the minimum-spec 4
+   vCPU / 8GB node it's a few minutes; on a smaller node, expect much longer -- on a 2
+   vCPU / 4GB node in testing, this step alone took **~30 minutes**, with every other
+   pod also contending for that same limited CPU. See [Resources](#resources).
+3. The API pod stays at `0/1 Ready` for this entire window by design -- it's blocked on
+   the migration Job finishing, not crashing. Once migrations complete, the API starts
+   gunicorn and flips to `1/1 Ready` within seconds.
+4. Every other service pod (web, space, admin, live, workers) comes up independently of
+   the API and is usually `1/1 Ready` well before it.
+
+### Confirm Plane is running
+
+```bash
+kubectl get pods -n traefik
+kubectl get pods -n plane
+```
+
+All pods `Running`/`Completed` and the `api-wl` pod at `1/1 Ready` means it's fully up.
+If `api-wl` is still `0/1`, check whether the migration Job has finished:
+
+```bash
+kubectl get jobs -n plane
+```
+
+A `Running` migration Job with `0/1` completions is normal and not stuck -- see timing
+above.
+
+### Domain and access
+
+DigitalOcean's Kubernetes 1-Click flow gives `deploy.sh` no form field to collect a
+domain, so on first install it derives a working hostname for you automatically from
+Traefik's own LoadBalancer IP: `plane.<ip>.sslip.io`, using [sslip.io](https://sslip.io)'s
+wildcard DNS (the same "no DNS setup needed" pattern Knative, Epinio and other Kubernetes
+platforms default to -- `plane.<ip>.sslip.io` always resolves back to `<ip>`, nothing to
+configure). Get that IP, then visit the app:
+
+```bash
+kubectl get svc traefik --namespace traefik -o jsonpath='{.status.loadBalancer.ingress[0].ip}'
+# -> e.g. 129.212.245.103
+```
+
+Open `http://plane.<that-ip>.sslip.io` in your browser -- e.g.
+`http://plane.129.212.245.103.sslip.io` -- and you'll land on Plane's workspace setup
+flow.
+
+To point your own domain at it instead, once you have terminal access to the cluster:
+
+1. Get the Traefik LoadBalancer's external IP with the command above.
+2. Create an `A` record for your domain pointing at that IP, then switch to it:
+
+   ```bash
+   DOMAIN_NAME=plane.example.com ./upgrade.sh
+   ```
+
+   This sets `license.licenseDomain`, which Plane's Traefik `IngressRoute` matches on --
+   your domain will 404/not route until this step.
+
+This stack serves over plain HTTP; see below for TLS.
+
+### Adding a commercial license
+
+Plane Enterprise runs on its free tier by default. To attach a paid plan license key
+obtained from [prime.plane.so](https://prime.plane.so), see the `license` section of the
+[chart README](https://github.com/makeplane/helm-charts/blob/main/charts/plane-enterprise/README.md).
+
+### Customizing beyond this 1-click
+
+`deploy.sh`/`upgrade.sh` deliberately expose only `DOMAIN_NAME` and `PLANE_VERSION` --
+DigitalOcean's automated 1-Click flow can't pass in anything else, so there was no point
+building more surface than that into the scripts. Everything else the chart supports is
+still available; you just apply it yourself with `helm upgrade` once connected to your
+cluster, referencing the [full chart README](https://github.com/makeplane/helm-charts/blob/main/charts/plane-enterprise/README.md)
+for the exact keys. Common examples:
+
+- **TLS** via cert-manager (`ssl.createIssuer`, `ssl.issuer`, etc. -- install cert-manager
+  yourself first, e.g. DigitalOcean's own 1-Click for it, or bring your own certificate
+  via `ssl.tls_secret_name`).
+- **DigitalOcean Managed PostgreSQL/Valkey/OpenSearch** instead of the bundled
+  StatefulSets (`services.postgres.local_setup: false` + `env.pgdb_remote_url`, and the
+  equivalent `local_setup`/`*_remote_url` keys for Valkey and OpenSearch).
+- **DigitalOcean Spaces** instead of bundled MinIO (`services.minio.local_setup: false`
+  + `env.aws_access_key`/`aws_secret_access_key`/`aws_region`/`aws_s3_endpoint_url`,
+  pointing at `https://<region>.digitaloceanspaces.com`).
+
+RabbitMQ has no DigitalOcean managed equivalent, so it's always deployed from the
+bundled StatefulSet regardless.
+
+```bash
+helm show values plane/plane-enterprise > my-values.yaml
+# edit my-values.yaml
+helm upgrade plane-app plane/plane-enterprise \
+  --namespace plane \
+  --reuse-values \
+  -f my-values.yaml
+```
+
+`--reuse-values` matters here -- without it you'd drop the per-deployment secrets
+`deploy.sh` generated on first install (see below).
+
+### Secrets
+
+`deploy.sh` generates random values for every secret the chart would otherwise ship with
+a fixed default (Django's `SECRET_KEY`, the live-collaboration server secret, Silo's
+HMAC/AES keys, and the bundled Postgres/RabbitMQ/MinIO/OpenSearch credentials) --
+**only on first install**. Every later `deploy.sh` or `upgrade.sh` run passes
+`--reuse-values` and does not regenerate them, since the running Postgres/RabbitMQ/MinIO
+instances, and any sessions or tokens already signed with the old keys, depend on them
+staying the same. You never need to handle these values yourself.
+
+### Using a custom StorageClass
+
+This stack pins `env.storageClass` to `do-block-storage`, DOKS's default. If you're
+running a different or non-default StorageClass, pass
+`--set env.storageClass=<your-storageclass-name>` with `--reuse-values` as shown above.
+
+## Additional Resources
+
+- [Plane documentation](https://developers.plane.so/)
+- [Plane Helm chart reference](https://github.com/makeplane/helm-charts/blob/main/charts/plane-enterprise/README.md)
+- [Plane on GitHub](https://github.com/makeplane/plane)
+
+## Report bugs or ask questions
+
+To report an issue with this 1-Click, or with the underlying Helm chart, open an issue
+against [makeplane/helm-charts](https://github.com/makeplane/helm-charts/issues).

--- a/stacks/plane/deploy.sh
+++ b/stacks/plane/deploy.sh
@@ -1,0 +1,139 @@
+#!/bin/sh
+
+set -e
+
+_rand() {
+  LC_CTYPE=C LC_ALL=C tr -dc 'A-Za-z0-9' < /dev/urandom | head -c "${1:-40}"
+}
+
+################################################################################
+# repos
+################################################################################
+helm repo add traefik https://traefik.github.io/charts
+helm repo add plane https://helm.plane.so/
+helm repo update > /dev/null
+
+################################################################################
+# ingress controller
+################################################################################
+# plane-enterprise needs an ingress controller to be reachable at all -- it
+# doesn't expose any service directly. DigitalOcean's Kubernetes 1-Click flow
+# gives us no way to ask the user whether one is already installed, so this
+# stack packages its own rather than treating it as a prerequisite.
+# Idempotent: re-running this is a no-op if it's already at this version.
+TRAEFIK_CHART_VERSION="37.4.0"
+
+helm upgrade traefik traefik/traefik \
+  --create-namespace \
+  --install \
+  --namespace traefik \
+  --version "$TRAEFIK_CHART_VERSION" \
+  --wait
+
+################################################################################
+# chart
+################################################################################
+STACK="plane-app"
+CHART="plane/plane-enterprise"
+CHART_VERSION="3.5.2"
+NAMESPACE="plane"
+
+if [ -z "${MP_KUBERNETES}" ]; then
+  # use local version of values.yml
+  ROOT_DIR=$(git rev-parse --show-toplevel)
+  values="$ROOT_DIR/stacks/plane/values.yml"
+else
+  # use github hosted master version of values.yml
+  values="https://raw.githubusercontent.com/digitalocean/marketplace-kubernetes/master/stacks/plane/values.yml"
+fi
+
+# --reuse-values carries forward everything set below (secrets, domain, ...)
+# on every later deploy.sh/upgrade.sh run that doesn't re-specify it. On a
+# true first install there's nothing yet to reuse, so it's a no-op here.
+set -- --create-namespace \
+  --install \
+  --namespace "$NAMESPACE" \
+  --values "$values" \
+  --version "$CHART_VERSION" \
+  --timeout 15m0s \
+  --wait-for-jobs \
+  --reuse-values
+
+FIRST_INSTALL=false
+if ! helm status "$STACK" --namespace "$NAMESPACE" > /dev/null 2>&1; then
+  FIRST_INSTALL=true
+fi
+
+################################################################################
+# per-deployment secrets (first install only)
+################################################################################
+# Several defaults in the upstream chart -- the Django SECRET_KEY, the
+# live-collaboration server secret, Silo's HMAC/AES keys, and the bundled
+# Postgres/RabbitMQ/MinIO/OpenSearch credentials -- are fixed strings baked
+# into the chart's own values.yaml and templates. Left as-is, every install
+# of this stack across every DigitalOcean customer would share the exact
+# same secrets, which are public right there in the chart source. Generate
+# fresh ones on first install only: regenerating on top of an existing
+# release would desync the app from credentials already written into
+# Postgres/RabbitMQ/MinIO, and from sessions/tokens already signed with the
+# old keys. --reuse-values above is what makes every later run keep these.
+if [ "$FIRST_INSTALL" = true ]; then
+  echo "First install for '$STACK' -- generating per-deployment secrets."
+  set -- "$@" \
+    --set env.secret_key="$(_rand 50)" \
+    --set env.live_server_secret_key="$(_rand 40)" \
+    --set env.pgdb_password="$(_rand 32)" \
+    --set services.rabbitmq.default_password="$(_rand 32)" \
+    --set services.minio.root_password="$(_rand 32)" \
+    --set services.opensearch.password="$(_rand 32)" \
+    --set env.silo_envs.hmac_secret_key="$(_rand 32)" \
+    --set env.silo_envs.aes_secret_key="$(_rand 32)" \
+    --set env.silo_envs.cursor_webhook_secret="$(_rand 32)"
+fi
+
+################################################################################
+# domain (first install only, unless DOMAIN_NAME is already given)
+################################################################################
+# Most users install this from the DigitalOcean portal/Marketplace tab,
+# which runs this script with no way to collect a domain first -- there's no
+# form field for it, and no one is at a terminal to pass DOMAIN_NAME. But
+# Plane's ingress only routes on hostname, so without one the app deploys
+# healthy and nothing reaches it. Derive a working hostname from Traefik's
+# own LoadBalancer IP via sslip.io's wildcard DNS ("plane.<ip>.sslip.io"
+# always resolves back to <ip>, no DNS setup needed) -- the same pattern
+# Knative/Epinio/Verrazzano use for exactly this bootstrap problem. Anyone
+# who *does* have terminal access and a real domain can point it at the
+# same IP and switch with:
+#   DOMAIN_NAME=plane.example.com ./upgrade.sh
+if [ -z "${DOMAIN_NAME}" ] && [ "$FIRST_INSTALL" = true ]; then
+  echo "No DOMAIN_NAME given -- waiting for Traefik's LoadBalancer IP so Plane is reachable immediately (DigitalOcean Load Balancers can take a couple of minutes to provision)..."
+  TRIES=0
+  LB_IP=""
+  while [ -z "$LB_IP" ] && [ "$TRIES" -lt 60 ]; do
+    LB_IP=$(kubectl get svc traefik --namespace traefik -o jsonpath='{.status.loadBalancer.ingress[0].ip}' 2>/dev/null)
+    if [ -z "$LB_IP" ]; then
+      TRIES=$((TRIES + 1))
+      sleep 5
+    fi
+  done
+
+  if [ -n "$LB_IP" ]; then
+    DOMAIN_NAME="plane.${LB_IP}.sslip.io"
+    echo "Using $DOMAIN_NAME (Traefik LoadBalancer IP: $LB_IP)."
+  else
+    echo "Timed out waiting for Traefik's LoadBalancer IP -- continuing without a domain. Plane will deploy healthy but won't be reachable until you set one: DOMAIN_NAME=<yours> ./upgrade.sh" >&2
+  fi
+fi
+
+if [ -n "${DOMAIN_NAME}" ]; then
+  set -- "$@" --set license.licenseDomain="$DOMAIN_NAME"
+fi
+
+# PLANE_VERSION: the Plane application version (distinct from CHART_VERSION
+# above, which pins the Helm chart itself). Leave unset for the chart's own
+# default.
+if [ -n "${PLANE_VERSION}" ]; then
+  set -- "$@" --set planeVersion="$PLANE_VERSION"
+fi
+
+helm upgrade "$STACK" "$CHART" "$@"

--- a/stacks/plane/uninstall.sh
+++ b/stacks/plane/uninstall.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+set -e
+
+################################################################################
+# chart
+################################################################################
+STACK="plane-app"
+NAMESPACE="plane"
+
+helm uninstall "$STACK" \
+  --namespace "$NAMESPACE"
+kubectl delete --ignore-not-found=true namespace "$NAMESPACE"
+
+# The Traefik controller installed by deploy.sh is left in place -- other
+# apps in the cluster may depend on it. Remove it yourself if nothing else
+# uses it:
+#   helm uninstall traefik --namespace traefik
+#   kubectl delete --ignore-not-found=true namespace traefik

--- a/stacks/plane/upgrade.sh
+++ b/stacks/plane/upgrade.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+
+set -e
+
+################################################################################
+# repo
+################################################################################
+helm repo add plane https://helm.plane.so/
+helm repo update > /dev/null
+
+################################################################################
+# chart
+################################################################################
+STACK="plane-app"
+CHART="plane/plane-enterprise"
+NAMESPACE="plane"
+
+if [ -z "${MP_KUBERNETES}" ]; then
+  # use local version of values.yml
+  ROOT_DIR=$(git rev-parse --show-toplevel)
+  values="$ROOT_DIR/stacks/plane/values.yml"
+else
+  # use github hosted master version of values.yml
+  values="https://raw.githubusercontent.com/digitalocean/marketplace-kubernetes/master/stacks/plane/values.yml"
+fi
+
+# --reuse-values keeps everything deploy.sh set previously (the per-install
+# secrets, above all) for any key not re-specified below. This script never
+# generates secrets itself -- only deploy.sh does, and only on first install.
+set -- --namespace "$NAMESPACE" --values "$values" --reuse-values
+
+# DOMAIN_NAME: deploy.sh auto-derives a working <traefik-lb-ip>.sslip.io
+# domain on first install. Once you have a real domain, point its DNS at
+# that same LoadBalancer IP and switch to it here, e.g.:
+#   DOMAIN_NAME=plane.example.com ./upgrade.sh
+if [ -n "${DOMAIN_NAME}" ]; then
+  set -- "$@" --set license.licenseDomain="$DOMAIN_NAME"
+fi
+
+# PLANE_VERSION: the Plane application version (distinct from the Helm
+# chart version, which this script does not pin -- see deploy.sh).
+if [ -n "${PLANE_VERSION}" ]; then
+  set -- "$@" --set planeVersion="$PLANE_VERSION"
+fi
+
+helm upgrade "$STACK" "$CHART" "$@"

--- a/stacks/plane/values.yml
+++ b/stacks/plane/values.yml
@@ -1,0 +1,33 @@
+# plane/plane-enterprise
+#
+# DigitalOcean Kubernetes (DOKS) defaults for the 1-Click install.
+#
+# This stack is intentionally plain: DigitalOcean's Kubernetes 1-Click flow
+# runs deploy.sh with no way for the user to pass in values or environment
+# variables, so everything here has to work with zero input. It always
+# deploys the bundled Postgres/Valkey/RabbitMQ/MinIO StatefulSets, and always
+# installs its own Traefik. If you want to point at DigitalOcean Managed
+# Databases/Spaces, or add TLS via cert-manager, do that afterwards yourself
+# with `helm upgrade` directly -- see this stack's README.
+#
+# The one thing deploy.sh does set dynamically (via `--set`, not here) is
+# license.licenseDomain, derived from Traefik's LoadBalancer IP so Plane is
+# reachable immediately with no DNS step. See deploy.sh.
+#
+# storageClass
+# ------------
+# DOKS provisions volumes dynamically through the "do-block-storage"
+# StorageClass. This chart's PVC templates render
+# `storageClassName: {{ .Values.env.storageClass | quote }}` unconditionally,
+# so leaving env.storageClass empty produces `storageClassName: ""` on every
+# PVC -- which tells Kubernetes to bind ONLY a pre-existing PV and never
+# triggers dynamic provisioning, even though "do-block-storage" is marked
+# default on the cluster. Without this override, the bundled Postgres/Valkey/
+# RabbitMQ/MinIO PVCs sit Pending forever and the install never becomes
+# ready.
+env:
+  storageClass: do-block-storage
+
+ingress:
+  enabled: true
+  ingressClass: traefik


### PR DESCRIPTION
## Summary

Adds a new `stacks/plane` 1-Click App for [Plane Commercial](https://plane.so/), a
project/issue tracking tool. On a fresh DOKS cluster this deploys standalone with no
configuration required:

- Installs its own Traefik ingress controller (pinned) and waits for its DigitalOcean
  LoadBalancer IP.
- Bundles Postgres, Valkey (Redis), RabbitMQ and MinIO via the upstream chart's own
  StatefulSets, backed by DigitalOcean Block Storage (`do-block-storage`).
- Derives a working `plane.<lb-ip>.sslip.io` domain automatically on first install,
  since the Kubernetes 1-Click flow has no way to collect a domain up front, and
  Plane's ingress only routes on hostname.
- Generates unique per-deployment secrets (Django `SECRET_KEY`, live-collaboration
  secret, Silo HMAC/AES keys, bundled datastore credentials) on first install only,
  persisted across `upgrade.sh` runs via `--reuse-values` -- the upstream chart ships
  fixed default values for these that would otherwise be shared across every install
  of this stack.

`deploy.sh`/`upgrade.sh` intentionally expose only `DOMAIN_NAME` and `PLANE_VERSION` as
optional overrides; further customization (TLS via cert-manager, DigitalOcean Managed
Databases/Spaces instead of the bundled StatefulSets) is documented in the stack's
README as a direct `helm upgrade --reuse-values` the user runs themselves, since the
automated 1-Click flow can't pass in anything else.

## Test plan

- [x] `helm lint`/`helm template` against the upstream `plane-enterprise` chart with
      this stack's `values.yml`, including the secret and domain overrides
      `deploy.sh` applies.
- [x] Ran `deploy.sh` end-to-end against a live DOKS cluster (2 vCPU / 4GB nodes):
      Traefik installed and got a LoadBalancer IP, all bundled datastores came up,
      migrations completed, and the app was reachable at the auto-derived
      `plane.<lb-ip>.sslip.io` domain -- verified `/`, `/api/instances/`, `/spaces/`
      and `/god-mode/` all return `200` through the ingress.
- [x] Verified generated secrets (`SECRET_KEY`, MinIO root password, Postgres
      password, Silo HMAC/AES keys) are unique random values, not the chart's public
      defaults.
- [x] `uninstall.sh` removes the release and namespace cleanly.

