### PR TITLE
Add betterdb-monitor stack

### DIFF
--- a/stacks/betterdb-monitor/deploy.sh
+++ b/stacks/betterdb-monitor/deploy.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+
+set -e
+
+################################################################################
+# repo
+################################################################################
+helm repo add betterdb https://docs.betterdb.com/charts
+helm repo update > /dev/null
+
+################################################################################
+# chart
+################################################################################
+STACK="betterdb-monitor"
+CHART="betterdb/betterdb-monitor"
+CHART_VERSION="0.40.0"
+NAMESPACE="betterdb-monitor"
+
+if [ -z "${MP_KUBERNETES}" ]; then
+  # use local version of values.yml
+  ROOT_DIR=$(git rev-parse --show-toplevel)
+  values="$ROOT_DIR/stacks/betterdb-monitor/values.yml"
+else
+  # use github hosted master version of values.yml
+  values="https://raw.githubusercontent.com/digitalocean/marketplace-kubernetes/master/stacks/betterdb-monitor/values.yml"
+fi
+
+helm upgrade "$STACK" "$CHART" \
+  --atomic \
+  --create-namespace \
+  --install \
+  --timeout 8m0s \
+  --namespace "$NAMESPACE" \
+  --values "$values" \
+  --version "$CHART_VERSION"

--- a/stacks/betterdb-monitor/uninstall.sh
+++ b/stacks/betterdb-monitor/uninstall.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+set -e
+
+################################################################################
+# chart
+################################################################################
+STACK="betterdb-monitor"
+NAMESPACE="betterdb-monitor"
+
+
+helm uninstall "$STACK" \
+  --namespace "$NAMESPACE"

--- a/stacks/betterdb-monitor/upgrade.sh
+++ b/stacks/betterdb-monitor/upgrade.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+set -e
+
+################################################################################
+# repo
+################################################################################
+helm repo add betterdb https://docs.betterdb.com/charts
+helm repo update > /dev/null
+
+################################################################################
+# chart
+################################################################################
+STACK="betterdb-monitor"
+CHART="betterdb/betterdb-monitor"
+NAMESPACE="betterdb-monitor"
+
+if [ -z "${MP_KUBERNETES}" ]; then
+    # use local version of values.yml
+    ROOT_DIR=$(git rev-parse --show-toplevel)
+    values="$ROOT_DIR/stacks/betterdb-monitor/values.yml"
+else
+    # use github hosted master version of values.yml
+    values="https://raw.githubusercontent.com/digitalocean/marketplace-kubernetes/master/stacks/betterdb-monitor/values.yml"
+fi
+
+helm upgrade "$STACK" "$CHART" \
+  --namespace "$NAMESPACE" \
+  --values "$values"

--- a/stacks/betterdb-monitor/values.yml
+++ b/stacks/betterdb-monitor/values.yml
@@ -1,0 +1,31 @@
+## Stack name: betterdb/betterdb-monitor
+## Chart ref: https://github.com/BetterDB-inc/monitor/tree/master/charts/betterdb-monitor
+## Docs: https://docs.betterdb.com/kubernetes
+
+## The chart defaults deploy a single replica with in-memory history storage
+## and a ClusterIP service. After deploy, access the dashboard with:
+##
+##   kubectl -n betterdb-monitor port-forward svc/betterdb-monitor 3001:3001
+##
+## then open http://localhost:3001 and add your Valkey/Redis connection in the
+## UI (Settings -> Connection).
+
+## Uncomment to preconfigure the Valkey/Redis instance to monitor. For a
+## password, prefer db.existingSecret over db.password (see chart values).
+##
+# db:
+#   host: my-valkey.default.svc.cluster.local
+#   port: 6379
+
+## Uncomment for durable history storage (slowlogs, metrics, events) in
+## PostgreSQL. The in-memory default loses history on pod restart.
+##
+# storage:
+#   type: postgres
+#   url: postgresql://user:password@host:5432/betterdb
+
+## Uncomment to expose the dashboard through a load balancer instead of
+## port-forwarding.
+##
+# service:
+#   type: LoadBalancer


### PR DESCRIPTION
Adds the betterdb-monitor stack, generated with utils/generate-stack.sh.

BetterDB Monitor is a monitoring dashboard for Valkey, Redis and Dragonfly. It persists slowlogs, command patterns and client activity for historical debugging, exports Prometheus metrics and OTLP telemetry, and detects anomalies in real time. Website: https://betterdb.com, source: https://github.com/BetterDB-inc/monitor, chart: https://docs.betterdb.com/charts (betterdb/betterdb-monitor 0.40.0, signed, also listed on Artifact Hub).

All three scripts were tested on a fresh DOKS cluster (1.36.3-do.4, fra1, single s-2vcpu-4gb node):

* deploy.sh: helm release installed atomically, pod Ready, dashboard reachable via port-forward. Connected the monitor to an in-cluster Valkey 8.1.10 pod and verified live polling and Prometheus metrics export for that connection.
* upgrade.sh: release upgraded to revision 2, status deployed.
* uninstall.sh: release removed, workloads terminated.

The default values.yml keeps the chart defaults (single replica, in-memory history storage, ClusterIP service) and documents opt-in overrides for preconfiguring the monitored database, durable PostgreSQL history storage, and LoadBalancer exposure.

We will reference this PR in the Vendor Portal listing once merged.
